### PR TITLE
Enable CORS

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -32,3 +32,6 @@ requests==2.23.0
 
 # The Debug Toolbar
 Flask-DebugToolbar==0.11.0
+
+#CORS
+flask-cors==3.0.8

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="time-tracker-api",
+    name="time-tracker-backend",
     packages=find_packages(),
     include_package_data=True,
 )

--- a/time_tracker_api/__init__.py
+++ b/time_tracker_api/__init__.py
@@ -45,8 +45,12 @@ def init_app(app: Flask):
         app.logger.setLevel(logging.INFO)
         add_debug_toolbar(app)
 
+    cors_origins = app.config.get('CORS_ORIGINS')
+    if cors_origins:
+        enable_cors(app, cors_origins)
 
-def add_debug_toolbar(app):
+
+def add_debug_toolbar(app: Flask):
     app.config['DEBUG_TB_PANELS'] = (
         'flask_debugtoolbar.panels.versions.VersionDebugPanel',
         'flask_debugtoolbar.panels.timer.TimerDebugPanel',
@@ -62,3 +66,10 @@ def add_debug_toolbar(app):
     from flask_debugtoolbar import DebugToolbarExtension
     toolbar = DebugToolbarExtension()
     toolbar.init_app(app)
+
+
+def enable_cors(app: Flask, cors_origins: str):
+    from flask_cors import CORS
+    cors_origins_list = cors_origins.split(",")
+    CORS(app, resources={r"/*": {"origins": cors_origins_list}})
+    app.logger.info("Set CORS access to [%s]" % cors_origins)

--- a/time_tracker_api/config.py
+++ b/time_tracker_api/config.py
@@ -11,6 +11,7 @@ class Config:
     PROPAGATE_EXCEPTIONS = True
     RESTPLUS_VALIDATE = True
     DEBUG = True
+    CORS_ORIGINS = "*"
 
 
 class DevelopmentConfig(Config):


### PR DESCRIPTION
This PR is meant to Enable CORS (#54) but also renames the main project from time-tracker-api to time-tracker-backend.