### PR TITLE
Closes #36 Allow to run migrations

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,11 +4,11 @@ export FLASK_APP=time_tracker_api
 
 # Common attributes
 ## In case you use an Azure SQL database, you must specify the database connection URI. Check out the README.md for more details
-#export DATABASE_URI=mssql+pyodbc://<user>:<password>@time-tracker-srv.database.windows.net/<database>?driver\=ODBC Driver 17 for SQL Server
+#export SQL_DATABASE_URI=mssql+pyodbc://<user>:<password>@time-tracker-srv.database.windows.net/<database>?driver\=ODBC Driver 17 for SQL Server
 
 ## For Azure Cosmos DB
 export DATABASE_ACCOUNT_URI=https://<project_db_name>.documents.azure.com:443
 export DATABASE_MASTER_KEY=<db_master_key>
 export DATABASE_NAME=<db_name>
 ### or
-# export DATABASE_URI=AccountEndpoint=<ACCOUNT_URI>;AccountKey=<ACCOUNT_KEY>
+# export COSMOS_DATABASE_URI=AccountEndpoint=<ACCOUNT_URI>;AccountKey=<ACCOUNT_KEY>

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ htmlcov/
 timetracker-api-postman-collection.json
 swagger.json
 
-# Ignore any SQLite generated database
+# SQLite databases
 *.db
+
+# Local migration files
+migration_status.csv

--- a/migrations/01-initialize-db.py
+++ b/migrations/01-initialize-db.py
@@ -1,0 +1,35 @@
+def up():
+    from commons.data_access_layer.cosmos_db import cosmos_helper
+    import azure.cosmos.exceptions as exceptions
+    from . import app
+
+    app.logger.info("Creating TimeTracker initial containers...")
+
+    try:
+        app.logger.info('- Project')
+        from time_tracker_api.projects.projects_model import container_definition as project_definition
+        cosmos_helper.create_container(project_definition)
+
+        app.logger.info('- Project type')
+        from time_tracker_api.project_types.project_types_model import container_definition as project_type_definition
+        cosmos_helper.create_container(project_type_definition)
+
+        app.logger.info('- Activity')
+        from time_tracker_api.activities.activities_model import container_definition as activity_definition
+        cosmos_helper.create_container(activity_definition)
+
+        app.logger.info('- Customer')
+        from time_tracker_api.customers.customers_model import container_definition as customer_definition
+        cosmos_helper.create_container(customer_definition)
+
+        app.logger.info('- Time entry')
+        from time_tracker_api.time_entries.time_entries_model import container_definition as time_entry_definition
+        cosmos_helper.create_container(time_entry_definition)
+    except exceptions.CosmosResourceExistsError as e:
+        app.logger.warning("Unexpected error while creating initial database schema: %s" % e.message)
+
+    app.logger.info("Done!")
+
+
+def down():
+    print("Not implemented!")

--- a/migrations/__init__.py
+++ b/migrations/__init__.py
@@ -1,0 +1,77 @@
+from azure.cosmos import PartitionKey
+from migrate_anything import configure
+from migrate_anything.storage import Storage
+
+from time_tracker_api import create_app
+
+
+class CustomStorage(object):
+    def __init__(self, file):
+        self.file = file
+
+    def save_migration(self, name, code):
+        with open(self.file, "a", encoding="utf-8") as file:
+            file.write("{},{}\n".format(name, code))
+
+    def list_migrations(self):
+        try:
+            with open(self.file, encoding="utf-8") as file:
+                return [
+                    line.split(",")
+                    for line in file.readlines()
+                    if line.strip()  # Skip empty lines
+                ]
+        except FileNotFoundError:
+            return []
+
+    def remove_migration(self, name):
+        migrations = [
+            migration for migration in self.list_migrations() if migration[0] != name
+        ]
+
+        with open(self.file, "w", encoding="utf-8") as file:
+            for row in migrations:
+                file.write("{},{}\n".format(*row))
+
+
+app = create_app('time_tracker_api.config.CLIConfig')
+from commons.data_access_layer.cosmos_db import cosmos_helper, init_app, CosmosDBRepository
+
+if cosmos_helper is None:
+    init_app(app)
+    from commons.data_access_layer.cosmos_db import cosmos_helper
+
+
+class CosmosDBStorage(Storage):
+    def __init__(self, collection_id, app_id):
+        self.collection_id = collection_id
+        self.app_id = app_id
+        migrations_definition = {
+            'id': collection_id,
+            'partition_key': PartitionKey(path='/app_id'),
+            'unique_key_policy': {
+                'uniqueKeys': [
+                    {'paths': ['/name']},
+                ]
+            }
+        }
+        cosmos_helper.create_container_if_not_exists(migrations_definition)
+        self.repository = CosmosDBRepository.from_definition(migrations_definition)
+
+    def save_migration(self, name, code):
+        self.repository.create({"id": name,
+                                "name": name,
+                                "code": code,
+                                "app_id": self.app_id})
+
+    def list_migrations(self):
+        migrations = self.repository.find_all(self.app_id)
+        return [
+            [item['name'], item['code']] for item in migrations
+        ]
+
+    def remove_migration(self, name):
+        self.repository.delete_permanently(name, self.app_id)
+
+
+configure(storage=CosmosDBStorage("migrations", "time-tracker-api"))

--- a/requirements/migrations.txt
+++ b/requirements/migrations.txt
@@ -1,0 +1,6 @@
+# requirements/migrations.txt
+
+# For running any kind of data migration
+
+# Migration tool
+migrate-anything==0.1.6

--- a/tests/commons/data_access_layer/cosmos_db_test.py
+++ b/tests/commons/data_access_layer/cosmos_db_test.py
@@ -507,3 +507,32 @@ def test_partial_update_should_not_find_element_that_is_already_deleted(
     except Exception as e:
         assert type(e) is CosmosResourceNotFoundError
         assert e.status_code == 404
+
+
+def test_delete_permanently_with_invalid_id_should_fail(
+        cosmos_db_repository: CosmosDBRepository,
+        sample_item: dict):
+    try:
+        cosmos_db_repository.delete_permanently(fake.uuid4(), sample_item['tenant_id'])
+        fail('It should have not found the deleted item')
+    except Exception as e:
+        assert type(e) is CosmosResourceNotFoundError
+        assert e.status_code == 404
+
+
+def test_delete_permanently_with_valid_id_should_succeed(
+        cosmos_db_repository: CosmosDBRepository,
+        sample_item: dict):
+    found_item = cosmos_db_repository.find(sample_item['id'], sample_item['tenant_id'])
+
+    assert found_item is not None
+    assert found_item['id'] == sample_item['id']
+
+    cosmos_db_repository.delete_permanently(sample_item['id'], sample_item['tenant_id'])
+
+    try:
+        cosmos_db_repository.find(sample_item['id'], sample_item['tenant_id'])
+        fail('It should have not found the deleted item')
+    except Exception as e:
+        assert type(e) is CosmosResourceNotFoundError
+        assert e.status_code == 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def cosmos_db_repository(app: Flask, cosmos_db_model) -> CosmosDBRepository:
             from commons.data_access_layer.cosmos_db import cosmos_helper
 
         app.logger.info("Creating Cosmos DB test models...")
-        cosmos_helper.create_container(cosmos_db_model)
+        cosmos_helper.create_container_if_not_exists(cosmos_db_model)
         app.logger.info("Cosmos DB test models created!")
 
         yield CosmosDBRepository.from_definition(cosmos_db_model)

--- a/time_tracker_api/activities/activities_model.py
+++ b/time_tracker_api/activities/activities_model.py
@@ -1,4 +1,4 @@
-import abc
+from azure.cosmos import PartitionKey
 
 from time_tracker_api.database import CRUDDao
 
@@ -32,3 +32,15 @@ def create_dao() -> ActivityDao:
             SQLCRUDDao.__init__(self, ActivitySQLModel)
 
     return ActivitySQLDao()
+
+
+container_definition = {
+    'id': 'activity',
+    'partition_key': PartitionKey(path='/tenant_id'),
+    'unique_key_policy': {
+        'uniqueKeys': [
+            {'paths': ['/name']},
+            {'paths': ['/deleted']},
+        ]
+    }
+}

--- a/time_tracker_api/config.py
+++ b/time_tracker_api/config.py
@@ -7,7 +7,7 @@ DISABLE_STR_VALUES = ("false", "0", "disabled")
 
 class Config:
     SECRET_KEY = generate_dev_secret_key()
-    DATABASE_URI = os.environ.get('DATABASE_URI')
+    SQL_DATABASE_URI = os.environ.get('SQL_DATABASE_URI')
     PROPAGATE_EXCEPTIONS = True
     RESTPLUS_VALIDATE = True
     DEBUG = True
@@ -23,12 +23,12 @@ class DevelopmentConfig(Config):
 class SQLConfig(Config):
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    DATABASE_URI = os.environ.get('DATABASE_URI')
-    SQLALCHEMY_DATABASE_URI = DATABASE_URI
+    SQL_DATABASE_URI = os.environ.get('SQL_DATABASE_URI')
+    SQLALCHEMY_DATABASE_URI = SQL_DATABASE_URI
 
 
 class CosmosDB(Config):
-    DATABASE_URI = os.environ.get('DATABASE_URI')
+    COSMOS_DATABASE_URI = os.environ.get('COSMOS_DATABASE_URI')
     DATABASE_ACCOUNT_URI = os.environ.get('DATABASE_ACCOUNT_URI')
     DATABASE_MASTER_KEY = os.environ.get('DATABASE_MASTER_KEY')
     DATABASE_NAME = os.environ.get('DATABASE_NAME')
@@ -38,8 +38,8 @@ class TestConfig(CosmosDB, SQLConfig):
     TESTING = True
     FLASK_DEBUG = True
     TEST_TABLE = 'tests'
-    DATABASE_URI = os.environ.get('DATABASE_URI')
-    SQLALCHEMY_DATABASE_URI = DATABASE_URI or 'sqlite:///:memory:'
+    SQL_DATABASE_URI = os.environ.get('SQL_DATABASE_URI')
+    SQLALCHEMY_DATABASE_URI = SQL_DATABASE_URI or 'sqlite:///:memory:'
 
 
 class ProductionConfig(Config):
@@ -49,8 +49,9 @@ class ProductionConfig(Config):
 
 
 class AzureConfig(CosmosDB):
-    DATABASE_URI = os.environ.get('DATABASE_URI', os.environ.get('SQLAZURECONNSTR_DATABASE_URI'))
-    SQLALCHEMY_DATABASE_URI = DATABASE_URI
+    SQL_DATABASE_URI = os.environ.get('SQL_DATABASE_URI', os.environ.get('SQLCONNSTR_DATABASE_URI'))
+    COSMOS_DATABASE_URI = os.environ.get('COSMOS_DATABASE_URI', os.environ.get('CUSTOMCONNSTR_COSMOS_DATABASE_URI'))
+    SQLALCHEMY_DATABASE_URI = SQL_DATABASE_URI
 
 
 class AzureDevelopmentConfig(DevelopmentConfig, AzureConfig):

--- a/time_tracker_api/customers/customers_model.py
+++ b/time_tracker_api/customers/customers_model.py
@@ -1,3 +1,5 @@
+from azure.cosmos import PartitionKey
+
 from time_tracker_api.database import CRUDDao
 
 
@@ -31,3 +33,15 @@ def create_dao() -> CustomerDao:
             SQLCRUDDao.__init__(self, CustomerSQLModel)
 
     return CustomerSQLDao()
+
+
+container_definition = {
+    'id': 'customer',
+    'partition_key': PartitionKey(path='/tenant_id'),
+    'unique_key_policy': {
+        'uniqueKeys': [
+            {'paths': ['/name']},
+            {'paths': ['/deleted']},
+        ]
+    }
+}

--- a/time_tracker_api/project_types/project_types_model.py
+++ b/time_tracker_api/project_types/project_types_model.py
@@ -1,3 +1,5 @@
+from azure.cosmos import PartitionKey
+
 from time_tracker_api.database import CRUDDao
 
 
@@ -33,3 +35,15 @@ def create_dao() -> ProjectTypeDao:
             SQLCRUDDao.__init__(self, ProjectTypeSQLModel)
 
     return ProjectTypeSQLDao()
+
+
+container_definition = {
+    'id': 'project_type',
+    'partition_key': PartitionKey(path='/customer_id'),
+    'unique_key_policy': {
+        'uniqueKeys': [
+            {'paths': ['/name']},
+            {'paths': ['/deleted']},
+        ]
+    }
+}

--- a/time_tracker_api/projects/projects_model.py
+++ b/time_tracker_api/projects/projects_model.py
@@ -1,5 +1,7 @@
 import enum
 
+from azure.cosmos import PartitionKey
+
 from time_tracker_api.database import CRUDDao
 
 
@@ -44,3 +46,15 @@ def create_dao() -> ProjectDao:
             SQLCRUDDao.__init__(self, ProjectSQLModel)
 
     return ProjectSQLDao()
+
+
+container_definition = {
+    'id': 'project',
+    'partition_key': PartitionKey(path='/tenant_id'),
+    'unique_key_policy': {
+        'uniqueKeys': [
+            {'paths': ['/name']},
+            {'paths': ['/deleted']},
+        ]
+    }
+}

--- a/time_tracker_api/projects/projects_namespace.py
+++ b/time_tracker_api/projects/projects_namespace.py
@@ -3,7 +3,7 @@ from flask_restplus import Namespace, Resource, fields
 from flask_restplus._http import HTTPStatus
 
 from time_tracker_api.api import audit_fields
-from time_tracker_api.projects.projects_model import PROJECT_TYPE, create_dao
+from time_tracker_api.projects.projects_model import create_dao
 
 faker = Faker()
 

--- a/time_tracker_api/time_entries/time_entries_model.py
+++ b/time_tracker_api/time_entries/time_entries_model.py
@@ -1,3 +1,4 @@
+from azure.cosmos import PartitionKey
 from sqlalchemy_utils import ScalarListType
 
 from time_tracker_api.database import CRUDDao
@@ -47,3 +48,15 @@ def create_dao() -> TimeEntriesDao:
             SQLCRUDDao.__init__(self, TimeEntrySQLModel)
 
     return TimeEntriesSQLDao()
+
+
+container_definition = {
+    'id': 'time_entry',
+    'partition_key': PartitionKey(path='/tenant_id'),
+    'unique_key_policy': {
+        'uniqueKeys': [
+            {'paths': ['/owner_id', '/end_date']},
+            {'paths': ['/deleted']},
+        ]
+    }
+}


### PR DESCRIPTION
In this PR it is installed and configured a library to run migrations. In addition, it creates an initial migration that creates an initial database schema. With containers for:
- Project
- Project type
- Activity
- Customer
- Time entry

Although the library for migrations we are using [is not perfect](https://github.com/Lieturd/migrate-anything/issues/3), we were able to run the migrations and persist them in Azure Cosmos DB.
