### PR TITLE
fix: Close #82 Enforce users manipulate only their time entries

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,7 @@ export FLASK_APP=time_tracker_api
 ## For Azure Cosmos DB
 export DATABASE_ACCOUNT_URI=https://<project_db_name>.documents.azure.com:443
 export DATABASE_MASTER_KEY=<db_master_key>
-export DATABASE_NAME=<db_name>
 ### or
 # export COSMOS_DATABASE_URI=AccountEndpoint=<ACCOUNT_URI>;AccountKey=<ACCOUNT_KEY>
+## Also specify the database name
+export DATABASE_NAME=<db_name>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,17 @@ def sample_item(cosmos_db_repository: CosmosDBRepository, tenant_id: str) -> dic
     return cosmos_db_repository.create(sample_item_data)
 
 
+@pytest.fixture(scope="function")
+def another_item(cosmos_db_repository: CosmosDBRepository, tenant_id: str) -> dict:
+    sample_item_data = dict(id=fake.uuid4(),
+                            name=fake.name(),
+                            email=fake.safe_email(),
+                            age=fake.pyint(min_value=10, max_value=80),
+                            tenant_id=tenant_id)
+
+    return cosmos_db_repository.create(sample_item_data)
+
+
 @pytest.yield_fixture(scope="module")
-def time_entry_repository(cosmos_db_repository: CosmosDBRepository) -> TimeEntryCosmosDBRepository:
+def time_entry_repository() -> TimeEntryCosmosDBRepository:
     return TimeEntryCosmosDBRepository()

--- a/tests/time_tracker_api/time_entries/time_entries_model_test.py
+++ b/tests/time_tracker_api/time_entries/time_entries_model_test.py
@@ -53,6 +53,7 @@ def test_find_interception_with_date_range_should_find(start_date: datetime,
     finally:
         time_entry_repository.delete_permanently(existing_item.id, partition_key_value=existing_item.tenant_id)
 
+
 def test_find_interception_should_ignore_id_of_existing_item(owner_id: str,
                                                              tenant_id: str,
                                                              time_entry_repository: TimeEntryCosmosDBRepository):
@@ -62,13 +63,13 @@ def test_find_interception_should_ignore_id_of_existing_item(owner_id: str,
     try:
 
         colliding_result = time_entry_repository.find_interception_with_date_range(start_date, end_date,
-                                                                         owner_id=owner_id,
-                                                                         partition_key_value=tenant_id)
+                                                                                   owner_id=owner_id,
+                                                                                   partition_key_value=tenant_id)
 
         non_colliding_result = time_entry_repository.find_interception_with_date_range(start_date, end_date,
-                                                                         owner_id=owner_id,
-                                                                         partition_key_value=tenant_id,
-                                                                         ignore_id=existing_item.id)
+                                                                                       owner_id=owner_id,
+                                                                                       partition_key_value=tenant_id,
+                                                                                       ignore_id=existing_item.id)
 
         colliding_result is not None
         assert any([existing_item.id == item.id for item in colliding_result])
@@ -77,4 +78,3 @@ def test_find_interception_should_ignore_id_of_existing_item(owner_id: str,
         assert not any([existing_item.id == item.id for item in non_colliding_result])
     finally:
         time_entry_repository.delete_permanently(existing_item.id, partition_key_value=existing_item.tenant_id)
-

--- a/tests/time_tracker_api/time_entries/time_entries_namespace_test.py
+++ b/tests/time_tracker_api/time_entries/time_entries_namespace_test.py
@@ -113,7 +113,9 @@ def test_get_time_entry_should_succeed_with_valid_id(client: FlaskClient, mocker
 
     assert HTTPStatus.OK == response.status_code
     fake_time_entry == json.loads(response.data)
-    repository_find_mock.assert_called_once_with(str(valid_id), partition_key_value=current_user_tenant_id())
+    repository_find_mock.assert_called_once_with(str(valid_id),
+                                                 partition_key_value=current_user_tenant_id(),
+                                                 peeker=ANY)
 
 
 def test_get_time_entry_should_response_with_unprocessable_entity_for_invalid_id_format(client: FlaskClient,
@@ -130,7 +132,9 @@ def test_get_time_entry_should_response_with_unprocessable_entity_for_invalid_id
     response = client.get("/time-entries/%s" % invalid_id, follow_redirects=True)
 
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
-    repository_find_mock.assert_called_once_with(str(invalid_id), partition_key_value=current_user_tenant_id())
+    repository_find_mock.assert_called_once_with(str(invalid_id),
+                                                 partition_key_value=current_user_tenant_id(),
+                                                 peeker=ANY)
 
 
 def test_update_time_entry_should_succeed_with_valid_data(client: FlaskClient, mocker: MockFixture):
@@ -148,7 +152,8 @@ def test_update_time_entry_should_succeed_with_valid_data(client: FlaskClient, m
     fake_time_entry == json.loads(response.data)
     repository_update_mock.assert_called_once_with(str(valid_id),
                                                    changes=valid_time_entry_input,
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_update_time_entry_should_reject_bad_request(client: FlaskClient, mocker: MockFixture):
@@ -185,7 +190,8 @@ def test_update_time_entry_should_return_not_found_with_invalid_id(client: Flask
     assert HTTPStatus.NOT_FOUND == response.status_code
     repository_update_mock.assert_called_once_with(str(invalid_id),
                                                    changes=valid_time_entry_input,
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_delete_time_entry_should_succeed_with_valid_id(client: FlaskClient, mocker: MockFixture):
@@ -200,7 +206,8 @@ def test_delete_time_entry_should_succeed_with_valid_id(client: FlaskClient, moc
     assert HTTPStatus.NO_CONTENT == response.status_code
     assert b'' == response.data
     repository_remove_mock.assert_called_once_with(str(valid_id),
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_delete_time_entry_should_return_not_found_with_invalid_id(client: FlaskClient,
@@ -216,7 +223,8 @@ def test_delete_time_entry_should_return_not_found_with_invalid_id(client: Flask
 
     assert HTTPStatus.NOT_FOUND == response.status_code
     repository_remove_mock.assert_called_once_with(str(invalid_id),
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_delete_time_entry_should_return_unprocessable_entity_for_invalid_id_format(client: FlaskClient,
@@ -232,7 +240,8 @@ def test_delete_time_entry_should_return_unprocessable_entity_for_invalid_id_for
 
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
     repository_remove_mock.assert_called_once_with(str(invalid_id),
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_stop_time_entry_with_valid_id(client: FlaskClient, mocker: MockFixture):
@@ -247,7 +256,8 @@ def test_stop_time_entry_with_valid_id(client: FlaskClient, mocker: MockFixture)
     assert HTTPStatus.OK == response.status_code
     repository_update_mock.assert_called_once_with(str(valid_id),
                                                    changes={"end_date": mocker.ANY},
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_stop_time_entry_with_id_with_invalid_format(client: FlaskClient, mocker: MockFixture):
@@ -263,7 +273,8 @@ def test_stop_time_entry_with_id_with_invalid_format(client: FlaskClient, mocker
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
     repository_update_mock.assert_called_once_with(invalid_id,
                                                    changes={"end_date": ANY},
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_restart_time_entry_with_valid_id(client: FlaskClient, mocker: MockFixture):
@@ -278,7 +289,8 @@ def test_restart_time_entry_with_valid_id(client: FlaskClient, mocker: MockFixtu
     assert HTTPStatus.OK == response.status_code
     repository_update_mock.assert_called_once_with(str(valid_id),
                                                    changes={"end_date": None},
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)
 
 
 def test_restart_time_entry_with_id_with_invalid_format(client: FlaskClient, mocker: MockFixture):
@@ -286,7 +298,8 @@ def test_restart_time_entry_with_id_with_invalid_format(client: FlaskClient, moc
     from werkzeug.exceptions import UnprocessableEntity
     repository_update_mock = mocker.patch.object(time_entries_dao.repository,
                                                  'partial_update',
-                                                 side_effect=UnprocessableEntity)
+                                                 side_effect=UnprocessableEntity,
+                                                 peeker=ANY)
     invalid_id = fake.word()
 
     response = client.post("/time-entries/%s/restart" % invalid_id, follow_redirects=True)
@@ -294,4 +307,5 @@ def test_restart_time_entry_with_id_with_invalid_format(client: FlaskClient, moc
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
     repository_update_mock.assert_called_once_with(invalid_id,
                                                    changes={"end_date": None},
-                                                   partition_key_value=current_user_tenant_id())
+                                                   partition_key_value=current_user_tenant_id(),
+                                                   peeker=ANY)

--- a/time_tracker_api/activities/activities_model.py
+++ b/time_tracker_api/activities/activities_model.py
@@ -15,7 +15,7 @@ container_definition = {
     'partition_key': PartitionKey(path='/tenant_id'),
     'unique_key_policy': {
         'uniqueKeys': [
-            {'paths': ['/name']},
+            {'paths': ['/name', '/deleted']},
         ]
     }
 }

--- a/time_tracker_api/activities/activities_namespace.py
+++ b/time_tracker_api/activities/activities_namespace.py
@@ -20,26 +20,13 @@ activity_input = ns.model('ActivityInput', {
     ),
     'description': fields.String(
         title='Description',
+        required=False,
         description='Comments about the activity',
         example=faker.paragraph(),
     )
 })
 
-activity_response_fields = {
-    'id': fields.String(
-        readOnly=True,
-        required=True,
-        title='Identifier',
-        description='The unique identifier',
-        example=faker.uuid4(),
-    ),
-    'tenant_id': fields.String(
-        required=True,
-        title='Identifier of Tenant',
-        description='Tenant this activity belongs to',
-        example=faker.uuid4(),
-    ),
-}
+activity_response_fields = {}
 activity_response_fields.update(common_fields)
 
 activity = ns.inherit(

--- a/time_tracker_api/api.py
+++ b/time_tracker_api/api.py
@@ -15,13 +15,33 @@ api = Api(
     description="API for the TimeTracker project"
 )
 
+# For matching UUIDs
+UUID_REGEX = '[0-9a-f]{8}\-[0-9a-f]{4}\-4[0-9a-f]{3}\-[89ab][0-9a-f]{3}\-[0-9a-f]{12}'
+
 # Common models structure
 common_fields = {
+    'id': fields.String(
+        title='Identifier',
+        readOnly=True,
+        required=True,
+        description='The unique identifier',
+        pattern=UUID_REGEX,
+        example=faker.uuid4(),
+    ),
+    'tenant_id': fields.String(
+        title='Identifier of Tenant',
+        readOnly=True,
+        required=True,
+        description='Tenant it belongs to',
+        # pattern=UUID_REGEX, This must be confirmed
+        example=faker.uuid4(),
+    ),
     'deleted': fields.String(
         readOnly=True,
         required=True,
         title='Last event Identifier',
         description='Last event over this resource',
+        pattern=UUID_REGEX,
     ),
 }
 

--- a/time_tracker_api/customers/customers_model.py
+++ b/time_tracker_api/customers/customers_model.py
@@ -15,7 +15,7 @@ container_definition = {
     'partition_key': PartitionKey(path='/tenant_id'),
     'unique_key_policy': {
         'uniqueKeys': [
-            {'paths': ['/name']},
+            {'paths': ['/name', '/deleted']},
         ]
     }
 }

--- a/time_tracker_api/customers/customers_namespace.py
+++ b/time_tracker_api/customers/customers_namespace.py
@@ -12,35 +12,22 @@ ns = Namespace('customers', description='API for customers')
 # Customer Model
 customer_input = ns.model('CustomerInput', {
     'name': fields.String(
-        required=True,
         title='Name',
+        required=True,
         max_length=50,
         description='Name of the customer',
         example=faker.company(),
     ),
     'description': fields.String(
         title='Description',
+        required=False,
         max_length=250,
         description='Description about the customer',
         example=faker.paragraph(),
     ),
 })
 
-customer_response_fields = {
-    'id': fields.String(
-        readOnly=True,
-        required=True,
-        title='Identifier',
-        description='The unique identifier',
-        example=faker.uuid4(),
-    ),
-    'tenant_id': fields.String(
-        required=True,
-        title='Identifier of Tenant',
-        description='Tenant this customer belongs to',
-        example=faker.uuid4(),
-    ),
-}
+customer_response_fields = {}
 customer_response_fields.update(common_fields)
 
 customer = ns.inherit(

--- a/time_tracker_api/project_types/project_types_model.py
+++ b/time_tracker_api/project_types/project_types_model.py
@@ -15,7 +15,7 @@ container_definition = {
     'partition_key': PartitionKey(path='/tenant_id'),
     'unique_key_policy': {
         'uniqueKeys': [
-            {'paths': ['/name', '/customer_id']},
+            {'paths': ['/name', '/customer_id', '/deleted']},
         ]
     }
 }

--- a/time_tracker_api/project_types/project_types_namespace.py
+++ b/time_tracker_api/project_types/project_types_namespace.py
@@ -2,7 +2,7 @@ from faker import Faker
 from flask_restplus import Namespace, Resource, fields
 from flask_restplus._http import HTTPStatus
 
-from time_tracker_api.api import common_fields
+from time_tracker_api.api import common_fields, UUID_REGEX
 from time_tracker_api.project_types.project_types_model import create_dao
 
 faker = Faker()
@@ -12,45 +12,37 @@ ns = Namespace('project-types', description='API for project types')
 # ProjectType Model
 project_type_input = ns.model('ProjectTypeInput', {
     'name': fields.String(
-        required=True,
         title='Name',
+        required=True,
         max_length=50,
         description='Name of the project type',
         example=faker.random_element(["Customer","Training","Internal"]),
     ),
     'description': fields.String(
         title='Description',
+        required=False,
         max_length=250,
-        description='Description about the project type',
+        description='Comments about the project type',
         example=faker.paragraph(),
     ),
     'customer_id': fields.String(
         title='Identifier of the Customer',
-        description='Customer this project type belongs to',
+        required=False,
+        description='Customer this project type belongs to. '
+                    'If not specified, it will be considered an internal project of the tenant.',
+        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
     'parent_id': fields.String(
-        title='Identifier of Parent of the project type',
-        description='Defines a self reference of the model ProjectType',
+        title='Identifier of the parent project type',
+        required=False,
+        description='This parent node allows to created a tree-like structure for project types',
+        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
 })
 
-project_type_response_fields = {
-    'id': fields.String(
-        readOnly=True,
-        required=True,
-        title='Identifier',
-        description='The unique identifier',
-        example=faker.uuid4(),
-    ),
-    'tenant_id': fields.String(
-        required=True,
-        title='Identifier of Tenant',
-        description='Tenant this project type belongs to',
-        example=faker.uuid4(),
-    ),
-}
+project_type_response_fields = {}
 project_type_response_fields.update(common_fields)
 
 project_type = ns.inherit(

--- a/time_tracker_api/projects/projects_model.py
+++ b/time_tracker_api/projects/projects_model.py
@@ -15,7 +15,7 @@ container_definition = {
     'partition_key': PartitionKey(path='/tenant_id'),
     'unique_key_policy': {
         'uniqueKeys': [
-            {'paths': ['/name', '/customer_id']},
+            {'paths': ['/name', '/customer_id', '/deleted']},
         ]
     }
 }

--- a/time_tracker_api/projects/projects_namespace.py
+++ b/time_tracker_api/projects/projects_namespace.py
@@ -2,7 +2,7 @@ from faker import Faker
 from flask_restplus import Namespace, Resource, fields
 from flask_restplus._http import HTTPStatus
 
-from time_tracker_api.api import common_fields
+from time_tracker_api.api import common_fields, UUID_REGEX
 from time_tracker_api.projects.projects_model import create_dao
 
 faker = Faker()
@@ -20,38 +20,30 @@ project_input = ns.model('ProjectInput', {
     ),
     'description': fields.String(
         title='Description',
+        required=False,
         max_length=250,
         description='Description about the project',
         example=faker.paragraph(),
     ),
     'customer_id': fields.String(
-        required=True,
         title='Identifier of the Customer',
-        description='Customer this project belongs to',
+        required=False,
+        description='Customer this project type belongs to. '
+                    'If not specified, it will be considered an internal project of the tenant.',
+        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
     'project_type_id': fields.String(
-        title='Identifier of Project type',
-        description='Type of the project. Used for grouping',
+        title='Identifier of the project type',
+        required=False,
+        description='This id allows to created a tree-like structure for projects, '
+                    'grouped by project types',
+        pattern=UUID_REGEX,
         example=faker.uuid4(),
-    )
+    ),
 })
 
-project_response_fields = {
-    'id': fields.String(
-        readOnly=True,
-        required=True,
-        title='Identifier',
-        description='The unique identifier',
-        example=faker.uuid4(),
-    ),
-    'tenant_id': fields.String(
-        required=False,
-        title='Identifier of Tenant',
-        description='Tenant this project belongs to',
-        example=faker.uuid4(),
-    ),
-}
+project_response_fields = {}
 project_response_fields.update(common_fields)
 
 project = ns.inherit(

--- a/time_tracker_api/time_entries/time_entries_namespace.py
+++ b/time_tracker_api/time_entries/time_entries_namespace.py
@@ -6,7 +6,7 @@ from flask_restplus._http import HTTPStatus
 
 from commons.data_access_layer.cosmos_db import current_datetime, datetime_str
 from commons.data_access_layer.database import COMMENTS_MAX_LENGTH
-from time_tracker_api.api import common_fields
+from time_tracker_api.api import common_fields, UUID_REGEX
 from time_tracker_api.time_entries.time_entries_model import create_dao
 
 faker = Faker()
@@ -19,12 +19,21 @@ time_entry_input = ns.model('TimeEntryInput', {
         title='Project',
         required=True,
         description='The id of the selected project',
+        pattern=UUID_REGEX,
         example=faker.uuid4(),
+    ),
+    'start_date': fields.DateTime(
+        dt_format='iso8601',
+        title='Start date',
+        required=True,
+        description='When the user started doing this activity',
+        example=datetime_str(current_datetime() - timedelta(days=1)),
     ),
     'activity_id': fields.String(
         title='Activity',
-        required=True,
+        required=False,
         description='The id of the selected activity',
+        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
     'description': fields.String(
@@ -33,13 +42,6 @@ time_entry_input = ns.model('TimeEntryInput', {
         description='Comments about the time entry',
         example=faker.paragraph(nb_sentences=2),
         max_length=COMMENTS_MAX_LENGTH,
-    ),
-    'start_date': fields.DateTime(
-        dt_format='iso8601',
-        title='Start date',
-        required=True,
-        description='When the user started doing this activity',
-        example=datetime_str(current_datetime() - timedelta(days=1)),
     ),
     'end_date': fields.DateTime(
         dt_format='iso8601',
@@ -50,7 +52,9 @@ time_entry_input = ns.model('TimeEntryInput', {
     ),
     'uri': fields.String(
         title='Uniform Resource identifier',
-        description='Either identifier or locator',
+        description='Either identifier or locator of a resource in the Internet that helps to understand'
+                    ' what this time entry was about. For example, A Jira ticket, a Github issue, a Google document.',
+        required=False,
         example=faker.random_element([
             'https://github.com/ioet/time-tracker-backend/issues/51',
             '#54',
@@ -75,24 +79,11 @@ time_entry_input = ns.model('TimeEntryInput', {
 })
 
 time_entry_response_fields = {
-    'id': fields.String(
-        readOnly=True,
-        title='Identifier',
-        description='The unique identifier',
-        example=faker.uuid4(),
-    ),
     'running': fields.Boolean(
         readOnly=True,
         title='Is it running?',
         description='Whether this time entry is currently running or not',
         example=faker.boolean(),
-    ),
-    'tenant_id': fields.String(
-        required=True,
-        readOnly=True,
-        title='Identifier of Tenant',
-        description='Tenant this project belongs to',
-        example=faker.uuid4(),
     ),
     'owner_id': fields.String(
         required=True,


### PR DESCRIPTION
In this PR we make possible change the model of the time entries, so that it is checked that the current user can only manipulate time entry items where he is the owner, otherwise he will get an 403 error:
![image](https://user-images.githubusercontent.com/6514740/79618808-b2d3cf80-80d0-11ea-87e4-b5c49e1691f3.png)

This is possible because of the new parameter `peeker` and `conditions`:
* peeker: It is a peeker that is meant to watch the item that is manipulated and if a biz-logic criteria requirement is not fulfilled it can short-circuit the user request flow by raising an `CustomError`.
* conditions: It is a python dictionary that contains the attribute and the corresponding expected value we expect the entries have in the database. This is done by creating an equality condition in the where clause of the SQL query executed in the function `find_all`.