### PR TITLE
feat: Close #89 Add endpoint to get running time entry

### DIFF
--- a/tests/time_tracker_api/time_entries/time_entries_model_test.py
+++ b/tests/time_tracker_api/time_entries/time_entries_model_test.py
@@ -78,3 +78,19 @@ def test_find_interception_should_ignore_id_of_existing_item(owner_id: str,
         assert not any([existing_item.id == item.id for item in non_colliding_result])
     finally:
         time_entry_repository.delete_permanently(existing_item.id, partition_key_value=existing_item.tenant_id)
+
+
+def test_find_running_should_return_running_time_entry(running_time_entry,
+                                                       time_entry_repository: TimeEntryCosmosDBRepository):
+   found_time_entry = time_entry_repository.find_running(partition_key_value=running_time_entry.tenant_id)
+
+   assert found_time_entry is not None
+   assert found_time_entry.id == running_time_entry.id
+
+
+def test_find_running_should_not_find_any_item(tenant_id: str,
+                                               time_entry_repository: TimeEntryCosmosDBRepository):
+    try:
+        time_entry_repository.find_running(partition_key_value=tenant_id)
+    except Exception as e:
+        assert type(e) is StopIteration

--- a/time_tracker_api/api.py
+++ b/time_tracker_api/api.py
@@ -77,7 +77,8 @@ def handle_cosmos_resource_exists_error(error):
 
 
 @api.errorhandler(CosmosResourceNotFoundError)
-def handle_cosmos_resource_not_found_error(error):
+@api.errorhandler(StopIteration)
+def handle_not_found_errors(error):
     return {'message': 'It was not found'}, HTTPStatus.NOT_FOUND
 
 

--- a/time_tracker_api/time_entries/time_entries_namespace.py
+++ b/time_tracker_api/time_entries/time_entries_namespace.py
@@ -171,7 +171,7 @@ class StopTimeEntry(Resource):
 
 @ns.route('/<string:id>/restart')
 @ns.response(HTTPStatus.NOT_FOUND, 'Stopped time entry not found')
-@ns.response(HTTPStatus.UNPROCESSABLE_ENTITY, 'The id has an invalid format.')
+@ns.response(HTTPStatus.UNPROCESSABLE_ENTITY, 'The id has an invalid format')
 @ns.param('id', 'The unique identifier of a stopped time entry')
 class RestartTimeEntry(Resource):
     @ns.doc('restart_time_entry')
@@ -181,3 +181,14 @@ class RestartTimeEntry(Resource):
         return time_entries_dao.update(id, {
             'end_date': None
         })
+
+
+@ns.route('/running')
+@ns.response(HTTPStatus.OK, 'The time entry that is active: currently running')
+@ns.response(HTTPStatus.NOT_FOUND, 'There is no time entry running right now')
+class ActiveTimeEntry(Resource):
+    @ns.doc('running_time_entry')
+    @ns.marshal_with(time_entry)
+    def get(self):
+        """Find the time entry that is running"""
+        return time_entries_dao.find_running()


### PR DESCRIPTION
This PR creates the endpoint 
>GET /time-entries/running

Which returns the time entry that is running at the moment. It returns:

* OK (200) and the data of the running time entry if there is one
* NOT_FOUND (404) whether there is no time entry