### PR TITLE
Close #107 Allow removing id by specifying null

### DIFF
--- a/commons/data_access_layer/cosmos_db.py
+++ b/commons/data_access_layer/cosmos_db.py
@@ -132,8 +132,13 @@ class CosmosDBRepository:
         if throw_not_found_if_deleted and item.get('deleted') is not None:
             raise exceptions.CosmosResourceNotFoundError(message='Deleted item',
                                                          status_code=404)
-
         return item
+
+    @staticmethod
+    def replace_empty_value_per_none(item_data: dict) -> dict:
+        for k, v in item_data.items():
+            if isinstance(v, str) and len(v) == 0:
+                item_data[k] = None
 
     def create(self, data: dict, mapper: Callable = None):
         self.on_create(data)
@@ -206,6 +211,8 @@ class CosmosDBRepository:
     def on_create(self, new_item_data: dict):
         if new_item_data.get('id') is None:
             new_item_data['id'] = generate_uuid4()
+
+        self.replace_empty_value_per_none(new_item_data)
 
     def on_update(self, update_item_data: dict):
         pass

--- a/tests/commons/data_access_layer/cosmos_db_test.py
+++ b/tests/commons/data_access_layer/cosmos_db_test.py
@@ -602,3 +602,28 @@ def test_datetime_str_comparison():
 
     assert now_str > datetime_str(now - timedelta(days=1))
     assert now_str < datetime_str(now + timedelta(days=1))
+
+
+def test_replace_empty_value_per_none(tenant_id: str):
+    initial_value = dict(id=fake.uuid4(),
+                 name=fake.name(),
+                 empty_str_attrib="",
+                 array_attrib=[1, 2, 3],
+                 empty_array_attrib=[],
+                 description="    ",
+                 age=fake.pyint(min_value=10, max_value=80),
+                 size=0,
+                 tenant_id=tenant_id)
+
+    input = initial_value.copy()
+
+    CosmosDBRepository.replace_empty_value_per_none(input)
+
+    assert input["name"] == initial_value["name"]
+    assert input["empty_str_attrib"] is None
+    assert input["array_attrib"] == initial_value["array_attrib"]
+    assert input["empty_array_attrib"] == initial_value["empty_array_attrib"]
+    assert input["description"] == initial_value["description"]
+    assert input["age"] == initial_value["age"]
+    assert input["size"] == initial_value["size"]
+    assert input["tenant_id"] == initial_value["tenant_id"]

--- a/tests/time_tracker_api/project_types/project_types_namespace_test.py
+++ b/tests/time_tracker_api/project_types/project_types_namespace_test.py
@@ -42,7 +42,7 @@ def test_create_project_type_should_reject_bad_request(client: FlaskClient,
     from time_tracker_api.project_types.project_types_namespace import project_type_dao
     invalid_project_type_data = valid_project_type_data.copy()
     invalid_project_type_data.update({
-        "parent_id": None,
+        "name": None,
     })
     repository_create_mock = mocker.patch.object(project_type_dao.repository,
                                                  'create',
@@ -166,7 +166,7 @@ def test_update_project_should_reject_bad_request(client: FlaskClient,
     from time_tracker_api.project_types.project_types_namespace import project_type_dao
     invalid_project_type_data = valid_project_type_data.copy()
     invalid_project_type_data.update({
-        "parent_id": None,
+        "name": None,
     })
     repository_update_mock = mocker.patch.object(project_type_dao.repository,
                                                  'partial_update',

--- a/time_tracker_api/activities/activities_namespace.py
+++ b/time_tracker_api/activities/activities_namespace.py
@@ -1,13 +1,13 @@
 from faker import Faker
-from flask_restplus import fields, Resource, Namespace
+from flask_restplus import fields, Resource
 from flask_restplus._http import HTTPStatus
 
 from time_tracker_api.activities.activities_model import create_dao
-from time_tracker_api.api import common_fields
+from time_tracker_api.api import common_fields, api
 
 faker = Faker()
 
-ns = Namespace('activities', description='API for activities')
+ns = api.namespace('activities', description='Namespace of the API for activities')
 
 # Activity Model
 activity_input = ns.model('ActivityInput', {

--- a/time_tracker_api/api.py
+++ b/time_tracker_api/api.py
@@ -38,30 +38,37 @@ def create_attributes_filter(ns: namespace, model: Model, filter_attrib_names: l
     return attribs_parser
 
 
-# Common models structure
+# Custom fields
+class NullableString(fields.String):
+    __schema_type__ = ['string', 'null']
+
+
+class UUID(NullableString):
+    def __init__(self, *args, **kwargs):
+        super(UUID, self).__init__(*args, **kwargs)
+        self.pattern = UUID_REGEX
+
+
 common_fields = {
-    'id': fields.String(
+    'id': UUID(
         title='Identifier',
         readOnly=True,
         required=True,
         description='The unique identifier',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
-    'tenant_id': fields.String(
+    'tenant_id': UUID(
         title='Identifier of Tenant',
         readOnly=True,
         required=True,
         description='Tenant it belongs to',
-        # pattern=UUID_REGEX, This must be confirmed
         example=faker.uuid4(),
     ),
-    'deleted': fields.String(
+    'deleted': UUID(
         readOnly=True,
         required=True,
         title='Last event Identifier',
         description='Last event over this resource',
-        pattern=UUID_REGEX,
     ),
 }
 

--- a/time_tracker_api/api.py
+++ b/time_tracker_api/api.py
@@ -46,7 +46,7 @@ class NullableString(fields.String):
 class UUID(NullableString):
     def __init__(self, *args, **kwargs):
         super(UUID, self).__init__(*args, **kwargs)
-        self.pattern = UUID_REGEX
+        self.pattern = r"^(|%s)$" % UUID_REGEX
 
 
 common_fields = {

--- a/time_tracker_api/customers/customers_namespace.py
+++ b/time_tracker_api/customers/customers_namespace.py
@@ -1,13 +1,13 @@
 from faker import Faker
-from flask_restplus import Namespace, Resource, fields
+from flask_restplus import Resource, fields
 from flask_restplus._http import HTTPStatus
 
-from time_tracker_api.api import common_fields
+from time_tracker_api.api import common_fields, api
 from time_tracker_api.customers.customers_model import create_dao
 
 faker = Faker()
 
-ns = Namespace('customers', description='API for customers')
+ns = api.namespace('customers', description='Namespace of the API for customers')
 
 # Customer Model
 customer_input = ns.model('CustomerInput', {

--- a/time_tracker_api/project_types/project_types_namespace.py
+++ b/time_tracker_api/project_types/project_types_namespace.py
@@ -1,14 +1,13 @@
 from faker import Faker
-from flask_restplus import Namespace, Resource, fields
+from flask_restplus import Resource, fields
 from flask_restplus._http import HTTPStatus
 
-from time_tracker_api.api import common_fields, create_attributes_filter
+from time_tracker_api.api import common_fields, create_attributes_filter, api, UUID
 from time_tracker_api.project_types.project_types_model import create_dao
-from time_tracker_api.security import UUID_REGEX
 
 faker = Faker()
 
-ns = Namespace('project-types', description='API for project types')
+ns = api.namespace('project-types', description='Namespace of the API for project types')
 
 # ProjectType Model
 project_type_input = ns.model('ProjectTypeInput', {
@@ -26,19 +25,17 @@ project_type_input = ns.model('ProjectTypeInput', {
         description='Comments about the project type',
         example=faker.paragraph(),
     ),
-    'customer_id': fields.String(
+    'customer_id': UUID(
         title='Identifier of the Customer',
         required=False,
         description='Customer this project type belongs to. '
                     'If not specified, it will be considered an internal project of the tenant.',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
-    'parent_id': fields.String(
+    'parent_id': UUID(
         title='Identifier of the parent project type',
         required=False,
         description='This parent node allows to created a tree-like structure for project types',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
 })

--- a/time_tracker_api/projects/projects_namespace.py
+++ b/time_tracker_api/projects/projects_namespace.py
@@ -1,14 +1,13 @@
 from faker import Faker
-from flask_restplus import Namespace, Resource, fields
+from flask_restplus import Resource, fields
 from flask_restplus._http import HTTPStatus
 
-from time_tracker_api.api import common_fields, create_attributes_filter
+from time_tracker_api.api import common_fields, create_attributes_filter, UUID, api
 from time_tracker_api.projects.projects_model import create_dao
-from time_tracker_api.security import UUID_REGEX
 
 faker = Faker()
 
-ns = Namespace('projects', description='API for projects (clients)')
+ns = api.namespace('projects', description='Namespace of the API for projects')
 
 # Project Model
 project_input = ns.model('ProjectInput', {
@@ -26,19 +25,17 @@ project_input = ns.model('ProjectInput', {
         description='Description about the project',
         example=faker.paragraph(),
     ),
-    'customer_id': fields.String(
+    'customer_id': UUID(
         title='Identifier of the Customer',
         required=False,
         description='Customer this project type belongs to. '
                     'If not specified, it will be considered an internal project of the tenant.',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
-    'project_type_id': fields.String(
+    'project_type_id': UUID(
         title='Identifier of the project type',
         required=False,
         description='Id of the project type it belongs. This allows grouping the projects.',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
 })

--- a/time_tracker_api/time_entries/time_entries_model.py
+++ b/time_tracker_api/time_entries/time_entries_model.py
@@ -85,6 +85,7 @@ class TimeEntryCosmosDBRepository(CosmosDBRepository):
     def on_update(self, updated_item_data: dict):
         CosmosDBRepository.on_update(self, updated_item_data)
         self.validate_data(updated_item_data)
+        self.replace_empty_value_per_none(updated_item_data)
 
     def find_interception_with_date_range(self, start_date, end_date, owner_id, partition_key_value,
                                           ignore_id=None, visible_only=True, mapper: Callable = None):

--- a/time_tracker_api/time_entries/time_entries_namespace.py
+++ b/time_tracker_api/time_entries/time_entries_namespace.py
@@ -1,26 +1,24 @@
 from datetime import timedelta
 
 from faker import Faker
-from flask_restplus import fields, Resource, Namespace
+from flask_restplus import fields, Resource
 from flask_restplus._http import HTTPStatus
 
 from commons.data_access_layer.cosmos_db import current_datetime, datetime_str, current_datetime_str
 from commons.data_access_layer.database import COMMENTS_MAX_LENGTH
-from time_tracker_api.api import common_fields, create_attributes_filter
-from time_tracker_api.security import UUID_REGEX
+from time_tracker_api.api import common_fields, create_attributes_filter, api, UUID
 from time_tracker_api.time_entries.time_entries_model import create_dao
 
 faker = Faker()
 
-ns = Namespace('time-entries', description='API for time entries')
+ns = api.namespace('time-entries', description='Namespace of the API for time entries')
 
 # TimeEntry Model
 time_entry_input = ns.model('TimeEntryInput', {
-    'project_id': fields.String(
+    'project_id': UUID(
         title='Project',
         required=True,
         description='The id of the selected project',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
     'start_date': fields.DateTime(
@@ -30,11 +28,10 @@ time_entry_input = ns.model('TimeEntryInput', {
         description='When the user started doing this activity',
         example=datetime_str(current_datetime() - timedelta(days=1)),
     ),
-    'activity_id': fields.String(
+    'activity_id': UUID(
         title='Activity',
         required=False,
         description='The id of the selected activity',
-        pattern=UUID_REGEX,
         example=faker.uuid4(),
     ),
     'description': fields.String(
@@ -86,7 +83,7 @@ time_entry_response_fields = {
         description='Whether this time entry is currently running or not',
         example=faker.boolean(),
     ),
-    'owner_id': fields.String(
+    'owner_id': UUID(
         required=True,
         readOnly=True,
         title='Owner of time entry',


### PR DESCRIPTION
This PR allows deleting optional ids by specifying `null` as value. Before that, this was not possible because a string was expected.
In addition, based on a request made by @enriquezrene , I allowed the `UUID` fields to match an empty string and before saving I matched in the `on_create` and `on_update` methods of the Cosmos DB repository whether an attribute was an empty text. If so, that value would be replaced by a `null` value.