### PR TITLE
fix: allow limits overlap in time entries #217

### DIFF
--- a/tests/time_tracker_api/time_entries/time_entries_model_test.py
+++ b/tests/time_tracker_api/time_entries/time_entries_model_test.py
@@ -1,37 +1,27 @@
-from datetime import datetime, timedelta
-
 import pytest
 from faker import Faker
 
-from utils.time import datetime_str, current_datetime
 from commons.data_access_layer.database import EventContext
 from time_tracker_api.time_entries.time_entries_model import (
     TimeEntryCosmosDBRepository,
     TimeEntryCosmosDBModel,
-    container_definition,
 )
-
-fake = Faker()
-
-now = current_datetime()
-yesterday = current_datetime() - timedelta(days=1)
-two_days_ago = current_datetime() - timedelta(days=2)
 
 
 def create_time_entry(
-    start_date: datetime,
-    end_date: datetime,
+    start_date: str,
+    end_date: str,
     owner_id: str,
     tenant_id: str,
     event_context: EventContext,
     time_entry_repository: TimeEntryCosmosDBRepository,
 ) -> TimeEntryCosmosDBModel:
     data = {
-        "project_id": fake.uuid4(),
-        "activity_id": fake.uuid4(),
-        "description": fake.paragraph(nb_sentences=2),
-        "start_date": datetime_str(start_date),
-        "end_date": datetime_str(end_date),
+        "project_id": Faker().uuid4(),
+        "activity_id": Faker().uuid4(),
+        "description": Faker().paragraph(nb_sentences=2),
+        "start_date": start_date,
+        "end_date": end_date,
         "owner_id": owner_id,
         "tenant_id": tenant_id,
     }
@@ -43,59 +33,146 @@ def create_time_entry(
 
 
 @pytest.mark.parametrize(
-    'start_date,end_date', [(two_days_ago, yesterday), (now, None)]
+    'start_date,end_date,start_date_,end_date_',
+    [
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+        ),
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T07:00:00.000Z",
+            "2020-10-01T12:00:00.000Z",
+        ),
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T02:00:00.000Z",
+            "2020-10-01T07:00:00.000Z",
+        ),
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T02:00:00.000Z",
+            "2020-10-01T12:00:00.000Z",
+        ),
+    ],
 )
 def test_find_interception_with_date_range_should_find(
-    start_date: datetime,
-    end_date: datetime,
+    start_date: str,
+    end_date: str,
+    start_date_: str,
+    end_date_: str,
     owner_id: str,
     tenant_id: str,
     time_entry_repository: TimeEntryCosmosDBRepository,
+    event_context: EventContext,
 ):
-    event_ctx = EventContext(
-        container_definition["id"],
-        "create",
-        tenant_id=tenant_id,
-        user_id=owner_id,
-    )
-
     existing_item = create_time_entry(
         start_date,
         end_date,
         owner_id,
         tenant_id,
-        event_ctx,
+        event_context,
         time_entry_repository,
     )
 
     try:
         result = time_entry_repository.find_interception_with_date_range(
-            datetime_str(yesterday), datetime_str(now), owner_id, tenant_id
+            start_date_, end_date_, owner_id, tenant_id
         )
 
         assert result is not None
         assert len(result) > 0
         assert any([existing_item.id == item.id for item in result])
     finally:
-        time_entry_repository.delete_permanently(existing_item.id, event_ctx)
+        time_entry_repository.delete_permanently(
+            existing_item.id, event_context
+        )
+
+
+@pytest.mark.parametrize(
+    'start_date,end_date,start_date_,end_date_',
+    [
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T15:00:00.000Z",
+        ),
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T12:00:00.000Z",
+            "2020-10-01T15:00:00.000Z",
+        ),
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T02:00:00.000Z",
+            "2020-10-01T05:00:00.000Z",
+        ),
+        (
+            "2020-10-01T05:00:00.000Z",
+            "2020-10-01T10:00:00.000Z",
+            "2020-10-01T02:00:00.000Z",
+            "2020-10-01T04:00:00.000Z",
+        ),
+    ],
+)
+def test_find_interception_with_date_range_should_not_find(
+    start_date: str,
+    end_date: str,
+    start_date_: str,
+    end_date_: str,
+    owner_id: str,
+    tenant_id: str,
+    time_entry_repository: TimeEntryCosmosDBRepository,
+    event_context: EventContext,
+):
+    existing_item = create_time_entry(
+        start_date,
+        end_date,
+        owner_id,
+        tenant_id,
+        event_context,
+        time_entry_repository,
+    )
+
+    try:
+        result = time_entry_repository.find_interception_with_date_range(
+            start_date_, end_date_, owner_id, tenant_id
+        )
+
+        assert result == []
+        assert len(result) == 0
+        assert not any([existing_item.id == item.id for item in result])
+    finally:
+        time_entry_repository.delete_permanently(
+            existing_item.id, event_context
+        )
 
 
 def test_find_interception_should_ignore_id_of_existing_item(
     owner_id: str,
     tenant_id: str,
     time_entry_repository: TimeEntryCosmosDBRepository,
+    event_context: EventContext,
 ):
-    event_ctx = EventContext(
-        container_definition["id"],
-        "create",
-        tenant_id=tenant_id,
-        user_id=owner_id,
-    )
-    start_date = datetime_str(yesterday)
-    end_date = datetime_str(now)
+    start_date = "2020-10-01T05:00:00.000Z"
+    end_date = "2020-10-01T10:00:00.000Z"
     existing_item = create_time_entry(
-        yesterday, now, owner_id, tenant_id, event_ctx, time_entry_repository
+        start_date,
+        end_date,
+        owner_id,
+        tenant_id,
+        event_context,
+        time_entry_repository,
     )
+
     try:
         colliding_result = time_entry_repository.find_interception_with_date_range(
             start_date, end_date, owner_id, tenant_id
@@ -109,15 +186,16 @@ def test_find_interception_should_ignore_id_of_existing_item(
             ignore_id=existing_item.id,
         )
 
-        colliding_result is not None
+        assert colliding_result is not None
         assert any([existing_item.id == item.id for item in colliding_result])
-
-        non_colliding_result is not None
+        assert non_colliding_result is not None
         assert not any(
             [existing_item.id == item.id for item in non_colliding_result]
         )
     finally:
-        time_entry_repository.delete_permanently(existing_item.id, event_ctx)
+        time_entry_repository.delete_permanently(
+            existing_item.id, event_context
+        )
 
 
 def test_find_running_should_return_running_time_entry(


### PR DESCRIPTION
Fixes https://github.com/ioet/time-tracker-ui/issues/504
Close #217 

This PR should fix the following problem: 
   You already have a time entry that starts at 11:00:00.
   Then, you want to create a time entry that starts at 9:00:00 and ends at 11:00:00.
   You can't because "There is already a time entry in that range"
   You have to explicitly set your new time entry to (9:00:00 - 10:59:00)

I excluded these cases from the validation that is made when creating/updating time-entries.

Check `time_tracker_api/time_entries/time_entries_model.py` lines 312, 313 for important changes. And `tests/time_tracker_api/time_entries/time_entries_model_test.py ` line 216 for important unit test.