### PR TITLE
refactor: TT-179 count method moved to TimeEntryCosmosDBRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ migration_status.csv
 
 # Mac
 .DS_Store
+
+# windows env variables
+.env.bat

--- a/tests/commons/data_access_layer/cosmos_db_test.py
+++ b/tests/commons/data_access_layer/cosmos_db_test.py
@@ -317,15 +317,6 @@ def test_find_all_with_offset(
     assert result_after_the_second_item == result_all_items[2:]
 
 
-def test_count(
-    cosmos_db_repository: CosmosDBRepository, event_context: EventContext
-):
-    counter = cosmos_db_repository.count(event_context)
-    print('test counter: ', counter)
-
-    assert counter == 10
-
-
 @pytest.mark.parametrize(
     'mapper,expected_type', [(None, dict), (dict, dict), (Person, Person)]
 )


### PR DESCRIPTION
Count method was moved from CosmosDBRepository to TimeEntryCosmosDBRepository, the test for that method was removed from tests\commons\data_access_layer\cosmos_db_test.py