### PR TITLE
fix: TT-257 customer name null on get project by id

### DIFF
--- a/tests/time_tracker_api/projects/projects_model_test.py
+++ b/tests/time_tracker_api/projects/projects_model_test.py
@@ -1,10 +1,14 @@
 from unittest.mock import Mock, patch
-import pytest
-
+from commons.data_access_layer.cosmos_db import CosmosDBDao
 from commons.data_access_layer.database import EventContext
+from time_tracker_api.customers.customers_model import (
+    CustomerCosmosDBModel,
+    CustomerCosmosDBDao,
+)
 from time_tracker_api.projects.projects_model import (
     ProjectCosmosDBRepository,
     ProjectCosmosDBModel,
+    create_dao,
 )
 
 
@@ -39,3 +43,37 @@ def test_find_all_projects_new_version(
     project = result[0]
     assert isinstance(project, ProjectCosmosDBModel)
     assert project.__dict__ == expected_item
+
+
+def test_get_project_with_their_customer(
+    mocker,
+):
+    project_data = {
+        'customer_id': 'dsakldh12ASD',
+        'id': 'JDKASDH12837',
+        'name': 'testing',
+        'description': 'do some testing',
+        'project_type_id': "id2",
+        'tenant_id': 'tenantid1',
+    }
+
+    customer_data = {
+        "id": "dsakldh12ASD",
+        "name": 'IOET inc.',
+        "description": 'nomatter',
+        "tenant_id": 'nomatter',
+    }
+
+    cosmos_db_get_mock = mocker.patch.object(CosmosDBDao, 'get')
+    customer_db_get_mock = mocker.patch.object(CustomerCosmosDBDao, 'get')
+
+    expected_customer = CustomerCosmosDBModel(customer_data)
+    expected_project = ProjectCosmosDBModel(project_data)
+
+    cosmos_db_get_mock.return_value = expected_project
+    customer_db_get_mock.return_value = expected_customer
+
+    project = create_dao().get('nomatterid')
+
+    assert isinstance(project, ProjectCosmosDBModel)
+    assert project.__dict__['customer_name'] == customer_data['name']

--- a/time_tracker_api/customers/customers_model.py
+++ b/time_tracker_api/customers/customers_model.py
@@ -44,13 +44,13 @@ class CustomerCosmosDBModel(CosmosDBModel):
         return "the customer \"%s\"" % self.name  # pragma: no cover
 
 
+class CustomerCosmosDBDao(APICosmosDBDao, CustomerDao):
+    def __init__(self, repository):
+        CosmosDBDao.__init__(self, repository)
+
+
 def create_dao() -> CustomerDao:
     repository = CosmosDBRepository.from_definition(
         container_definition, mapper=CustomerCosmosDBModel
     )
-
-    class CustomerCosmosDBDao(APICosmosDBDao, CustomerDao):
-        def __init__(self):
-            CosmosDBDao.__init__(self, repository)
-
-    return CustomerCosmosDBDao()
+    return CustomerCosmosDBDao(repository)

--- a/time_tracker_api/projects/projects_model.py
+++ b/time_tracker_api/projects/projects_model.py
@@ -115,7 +115,11 @@ class ProjectCosmosDBDao(APICosmosDBDao, ProjectDao):
         Get one project an active client
         :param (str) id: project's id
         """
-        return super().get(id)
+        project = super().get(id)
+        customer_dao = customers_create_dao()
+        customer = customer_dao.get(project.customer_id)
+        setattr(project, 'customer_name', customer.name)
+        return project
 
     @add_custom_attribute_in_list('customer', customers_create_dao)
     @add_custom_attribute_in_list('project_type', project_types_create_dao)


### PR DESCRIPTION
## Problem

There is an error when trying to consulting to the endpoint:

```bash
<time-tracker-backend-url>/projects/<project-id>
```
The response brings the customer name of the project **null**.

## Solution

The method **get** on **ProjectCosmosDBDao** class has been modified and add the correct behavior to fix this error.

Also, tests have been added to verify its correct operation.