### PR TITLE
fix: TT-302 Fix dependencies vulnerabilities

### DIFF
--- a/requirements/azure_cosmos.txt
+++ b/requirements/azure_cosmos.txt
@@ -9,7 +9,7 @@ certifi==2019.11.28
 chardet==3.0.4
 idna==2.8
 six==1.13.0
-urllib3==1.25.8
+urllib3==1.26.5
 virtualenv==16.7.9
 virtualenv-clone==0.5.3
 

--- a/requirements/commons.txt
+++ b/requirements/commons.txt
@@ -3,7 +3,7 @@
 # For Common dependencies
 
 # Handling requests
-requests==2.23.0
+requests==2.25.1
 
 # To create sample content in tests and API documentation
 Faker==4.0.2


### PR DESCRIPTION
## Description
Currently  we need to upgrade urllib3 to version 1.26.5 or later. Because earlier versions allows CRLF injection if the attacker controls the HTTP request method, The problem is that another package (`request==2.23.0`) needs `urllib3==1.25.8`

## Solution
The issue has been fixed in urllib3 v1.26.5, so we upgrade urllib3 to that version and we also upgrade request package to `2.25.1`

