### PR TITLE
fix: TT-303 Create activity with active status

### DIFF
--- a/tests/time_tracker_api/activities/activities_model_test.py
+++ b/tests/time_tracker_api/activities/activities_model_test.py
@@ -12,9 +12,6 @@ faker = Faker()
 
 
 @patch(
-    'time_tracker_api.activities.activities_model.ActivityCosmosDBRepository.create_sql_condition_for_visibility'
-)
-@patch(
     'time_tracker_api.activities.activities_model.ActivityCosmosDBRepository.find_partition_key_value'
 )
 def test_find_all_with_id_in_list(

--- a/time_tracker_api/activities/activities_model.py
+++ b/time_tracker_api/activities/activities_model.py
@@ -10,11 +10,7 @@ from commons.data_access_layer.cosmos_db import (
 from time_tracker_api.database import CRUDDao, APICosmosDBDao
 from typing import List, Callable
 from commons.data_access_layer.database import EventContext
-from utils.repository import (
-    convert_list_to_tuple_string,
-    create_sql_in_condition,
-)
-from utils.query_builder import CosmosDBQueryBuilder, Order
+from utils.query_builder import CosmosDBQueryBuilder
 
 
 class ActivityDao(CRUDDao):
@@ -149,6 +145,13 @@ class ActivityCosmosDBDao(APICosmosDBDao, ActivityDao):
             max_count=max_count,
         )
         return activities
+
+    def create(self, activity_payload: dict):
+        event_ctx = self.create_event_context('create')
+        activity_payload['status'] = 'active'
+        return self.repository.create(
+            data=activity_payload, event_context=event_ctx
+        )
 
 
 def create_dao() -> ActivityDao:


### PR DESCRIPTION
## Description
When we create a new activity, the default active state is not added, which causes errors when presenting in the UI, like this: 
![image](https://user-images.githubusercontent.com/56373098/128061433-5bb1500a-c76a-47b7-9d59-8c2b1412677a.png)

## Solution
With this PR this behavior is modified and an active status is added by default
