### PR TITLE
fix: TT-304 Handle message: the data could not be load

### DIFF
--- a/tests/time_tracker_api/time_entries/time_entries_repository_test.py
+++ b/tests/time_tracker_api/time_entries/time_entries_repository_test.py
@@ -95,7 +95,7 @@ def test_add_complementary_info_when_there_are_not_time_entries(
 ):
     with pytest.raises(HTTPException) as http_error:
         time_entry_repository.add_complementary_info(
-            time_entries=None, exist_conditions=False
+            time_entries=None, exist_conditions=True
         )
     status_code = http_error.value.code
     message = http_error.value.data.get('message')

--- a/time_tracker_api/time_entries/time_entries_repository.py
+++ b/time_tracker_api/time_entries/time_entries_repository.py
@@ -120,7 +120,7 @@ class TimeEntryCosmosDBRepository(CosmosDBRepository):
 
             users = AzureConnection().users()
             add_user_email_to_time_entries(time_entries, users)
-        elif not time_entries and not exist_conditions:
+        elif not time_entries and exist_conditions:
             abort(HTTPStatus.NOT_FOUND, "Time entry not found")
         return time_entries
 


### PR DESCRIPTION
**Problem**
------------
In the time-entries section, when there is no data, the message "The data could not be load" is displayed.
![Captura de Pantalla 2021-08-06 a la(s) 12 27 58](https://user-images.githubusercontent.com/12177501/128565947-926b229d-69fa-44a5-9983-4f7341fdbcf2.png)

**Solution**
------------
When there is no data, the message "The data could not be load" must not be displayed, instead the message "No data available in table" should be displayed in the table section. That is the purpose of this pull request.
![Captura de Pantalla 2021-08-06 a la(s) 12 19 29](https://user-images.githubusercontent.com/12177501/128566009-88685b70-c63f-4ae5-936b-f3019cf1a9fa.png)