### PR TITLE
refactor: TT-308 Use enums insted defined variables

### DIFF
--- a/cosmosdb_emulator/time_tracker_cli/providers/common.py
+++ b/cosmosdb_emulator/time_tracker_cli/providers/common.py
@@ -1,7 +1,9 @@
 from faker.providers import BaseProvider
 
+from utils.enums.status import Status
+
 
 class CommonProvider(BaseProvider):
     def status(self) -> str:
-        available_status = ['active', 'inactive']
+        available_status = [Status.ACTIVE.value, Status.INACTIVE.value]
         return self.random_element(elements=available_status)

--- a/tests/time_tracker_api/activities/activities_model_test.py
+++ b/tests/time_tracker_api/activities/activities_model_test.py
@@ -7,6 +7,7 @@ from time_tracker_api.activities.activities_model import (
     ActivityCosmosDBModel,
     create_dao,
 )
+from utils.enums.status import Status
 
 faker = Faker()
 
@@ -59,7 +60,7 @@ def test_create_activity_should_add_active_status(
     activity_dao.create(activity_payload)
 
     expect_argument = copy.copy(activity_payload)
-    expect_argument['status'] = 'active'
+    expect_argument['status'] = Status.ACTIVE.value
     activity_repository_create_mock.assert_called_with(
         data=expect_argument, event_context=ANY
     )

--- a/tests/time_tracker_api/activities/activities_namespace_test.py
+++ b/tests/time_tracker_api/activities/activities_namespace_test.py
@@ -6,6 +6,8 @@ from flask.testing import FlaskClient
 from flask_restplus._http import HTTPStatus
 from pytest_mock import MockFixture
 
+from utils.enums.status import Status
+
 fake = Faker()
 
 valid_activity_data = {
@@ -101,7 +103,7 @@ def test_list_all_active_activities(
 
     repository_find_all_mock.assert_called_once_with(
         event_context=ANY,
-        conditions={'status': 'active'},
+        conditions={'status': Status.ACTIVE.value},
         activities_id=ANY,
         visible_only=ANY,
         max_count=ANY,
@@ -259,7 +261,7 @@ def test_delete_activity_should_succeed_with_valid_id(
     assert HTTPStatus.NO_CONTENT == response.status_code
     assert b'' == response.data
     repository_remove_mock.assert_called_once_with(
-        str(valid_id), {'status': 'inactive'}, ANY
+        str(valid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 
@@ -283,7 +285,7 @@ def test_delete_activity_should_return_not_found_with_invalid_id(
 
     assert HTTPStatus.NOT_FOUND == response.status_code
     repository_remove_mock.assert_called_once_with(
-        str(invalid_id), {'status': 'inactive'}, ANY
+        str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 
@@ -309,5 +311,5 @@ def test_delete_activity_should_return_422_for_invalid_id_format(
 
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
     repository_remove_mock.assert_called_once_with(
-        str(invalid_id), {'status': 'inactive'}, ANY
+        str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )

--- a/tests/time_tracker_api/customers/customers_namespace_test.py
+++ b/tests/time_tracker_api/customers/customers_namespace_test.py
@@ -6,6 +6,8 @@ from flask.testing import FlaskClient
 from flask_restplus._http import HTTPStatus
 from pytest_mock import MockFixture
 
+from utils.enums.status import Status
+
 fake = Faker()
 
 valid_customer_data = {
@@ -229,7 +231,7 @@ def test_delete_customer_should_succeed_with_valid_id(
     assert HTTPStatus.NO_CONTENT == response.status_code
     assert b'' == response.data
     repository_remove_mock.assert_called_once_with(
-        str(valid_id), {'status': 'inactive'}, ANY
+        str(valid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 
@@ -253,7 +255,7 @@ def test_delete_customer_should_return_not_found_with_invalid_id(
 
     assert HTTPStatus.NOT_FOUND == response.status_code
     repository_remove_mock.assert_called_once_with(
-        str(invalid_id), {'status': 'inactive'}, ANY
+        str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 
@@ -282,7 +284,7 @@ def test_delete_customer_should_return_422_for_invalid_id_format(
 
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
     repository_remove_mock.assert_called_once_with(
-        str(invalid_id), {'status': 'inactive'}, ANY
+        str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 

--- a/tests/time_tracker_api/projects/projects_namespace_test.py
+++ b/tests/time_tracker_api/projects/projects_namespace_test.py
@@ -7,6 +7,7 @@ from flask_restplus._http import HTTPStatus
 from pytest_mock import MockFixture
 
 from time_tracker_api.projects.projects_model import ProjectCosmosDBDao
+from utils.enums.status import Status
 
 fake = Faker()
 
@@ -256,7 +257,7 @@ def test_delete_project_should_succeed_with_valid_id(
     assert HTTPStatus.NO_CONTENT == response.status_code
     assert b'' == response.data
     repository_remove_mock.assert_called_once_with(
-        str(valid_id), {'status': 'inactive'}, ANY
+        str(valid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 
@@ -280,7 +281,7 @@ def test_delete_project_should_return_not_found_with_invalid_id(
 
     assert HTTPStatus.NOT_FOUND == response.status_code
     repository_remove_mock.assert_called_once_with(
-        str(invalid_id), {'status': 'inactive'}, ANY
+        str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )
 
 
@@ -306,5 +307,5 @@ def test_delete_project_should_return_unprocessable_entity_for_invalid_id_format
 
     assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
     repository_remove_mock.assert_called_once_with(
-        str(invalid_id), {'status': 'inactive'}, ANY
+        str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )

--- a/tests/utils/query_builder_test.py
+++ b/tests/utils/query_builder_test.py
@@ -1,4 +1,6 @@
 from unittest.mock import patch
+
+from utils.enums.status import Status
 from utils.query_builder import CosmosDBQueryBuilder, Order
 from utils.repository import remove_white_spaces
 import pytest
@@ -376,7 +378,7 @@ def test_build_with_add_sql_date_range_condition():
 
 
 def test_add_sql_active_condition_should_update_where_conditions():
-    status_value = 'active'
+    status_value = Status.ACTIVE.value
     expected_active_query = f"""
         SELECT * FROM c
         WHERE NOT IS_DEFINED(c.status) OR (IS_DEFINED(c.status) AND c.status = '{status_value}')
@@ -399,7 +401,7 @@ def test_add_sql_active_condition_should_update_where_conditions():
 
 
 def test_add_sql_inactive_condition_should_update_where_conditions():
-    status_value = 'inactive'
+    status_value = Status.INACTIVE.value
     expected_inactive_query = f"""
         SELECT * FROM c
         WHERE (IS_DEFINED(c.status) AND c.status = '{status_value}')

--- a/time_tracker_api/activities/activities_model.py
+++ b/time_tracker_api/activities/activities_model.py
@@ -10,6 +10,7 @@ from commons.data_access_layer.cosmos_db import (
 from time_tracker_api.database import CRUDDao, APICosmosDBDao
 from typing import List, Callable
 from commons.data_access_layer.database import EventContext
+from utils.enums.status import Status
 from utils.query_builder import CosmosDBQueryBuilder
 
 
@@ -148,7 +149,7 @@ class ActivityCosmosDBDao(APICosmosDBDao, ActivityDao):
 
     def create(self, activity_payload: dict):
         event_ctx = self.create_event_context('create')
-        activity_payload['status'] = 'active'
+        activity_payload['status'] = Status.ACTIVE.value
         return self.repository.create(
             data=activity_payload, event_context=event_ctx
         )

--- a/time_tracker_api/activities/activities_namespace.py
+++ b/time_tracker_api/activities/activities_namespace.py
@@ -9,6 +9,7 @@ from time_tracker_api.api import (
     remove_required_constraint,
     NullableString,
 )
+from utils.enums.status import Status
 
 faker = Faker()
 
@@ -40,8 +41,8 @@ activity_input = ns.model(
             example=Faker().words(
                 2,
                 [
-                    'active',
-                    'inactive',
+                    Status.ACTIVE.value,
+                    Status.INACTIVE.value,
                 ],
                 unique=True,
             ),
@@ -117,5 +118,5 @@ class Activity(Resource):
     @ns.response(HTTPStatus.NO_CONTENT, 'Activity deleted successfully')
     def delete(self, id):
         """Delete an activity"""
-        activity_dao.update(id, {'status': 'inactive'})
+        activity_dao.update(id, {'status': Status.INACTIVE.value})
         return None, HTTPStatus.NO_CONTENT

--- a/time_tracker_api/customers/customers_model.py
+++ b/time_tracker_api/customers/customers_model.py
@@ -8,6 +8,7 @@ from commons.data_access_layer.cosmos_db import (
     CosmosDBDao,
 )
 from time_tracker_api.database import CRUDDao, APICosmosDBDao
+from utils.enums.status import Status
 
 
 class CustomerDao(CRUDDao):
@@ -32,7 +33,7 @@ class CustomerCosmosDBModel(CosmosDBModel):
     description: str
     deleted: str
     tenant_id: str
-    status: str = field(default='active')
+    status: str = field(default=Status.ACTIVE.value)
 
     def __init__(self, data):
         super(CustomerCosmosDBModel, self).__init__(data)  # pragma: no cover

--- a/time_tracker_api/customers/customers_namespace.py
+++ b/time_tracker_api/customers/customers_namespace.py
@@ -9,6 +9,7 @@ from time_tracker_api.api import (
     NullableString,
 )
 from time_tracker_api.customers.customers_model import create_dao
+from utils.enums.status import Status
 
 faker = Faker()
 
@@ -41,8 +42,8 @@ customer_input = ns.model(
             example=Faker().words(
                 2,
                 [
-                    'active',
-                    'inactive',
+                    Status.ACTIVE.value,
+                    Status.INACTIVE.value,
                 ],
                 unique=True,
             ),
@@ -122,5 +123,5 @@ class Customer(Resource):
     @ns.response(HTTPStatus.NO_CONTENT, 'Customer successfully deleted')
     def delete(self, id):
         """Delete a customer"""
-        customer_dao.update(id, {'status': 'inactive'})
+        customer_dao.update(id, {'status': Status.INACTIVE.value})
         return None, HTTPStatus.NO_CONTENT

--- a/time_tracker_api/projects/projects_namespace.py
+++ b/time_tracker_api/projects/projects_namespace.py
@@ -11,6 +11,7 @@ from time_tracker_api.api import (
     NullableString,
 )
 from time_tracker_api.projects.projects_model import create_dao
+from utils.enums.status import Status
 
 faker = Faker()
 
@@ -61,8 +62,8 @@ project_input = ns.model(
             example=Faker().words(
                 2,
                 [
-                    'active',
-                    'inactive',
+                    Status.ACTIVE.value,
+                    Status.INACTIVE.value,
                 ],
                 unique=True,
             ),
@@ -142,7 +143,7 @@ class Projects(Resource):
         """List all projects"""
         conditions = attributes_filter.parse_args()
         return project_dao.get_all(
-            conditions=conditions, customer_status='active'
+            conditions=conditions, customer_status=Status.ACTIVE.value
         )
 
     @ns.doc('create_project')
@@ -190,5 +191,5 @@ class Project(Resource):
     @ns.response(HTTPStatus.NO_CONTENT, 'Project successfully deleted')
     def delete(self, id):
         """Delete a project"""
-        project_dao.update(id, {'status': 'inactive'})
+        project_dao.update(id, {'status': Status.INACTIVE.value})
         return None, HTTPStatus.NO_CONTENT

--- a/utils/enums/status.py
+++ b/utils/enums/status.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Status(Enum):
+    ACTIVE = 'active'
+    INACTIVE = 'inactive'

--- a/utils/query_builder.py
+++ b/utils/query_builder.py
@@ -1,4 +1,6 @@
 from typing import List
+
+from utils.enums.status import Status
 from utils.repository import convert_list_to_tuple_string
 from enum import Enum
 
@@ -38,7 +40,7 @@ class CosmosDBQueryBuilder:
         if status_value:
             not_defined_condition = ''
             condition_operand = ''
-            if status_value == 'active':
+            if status_value == Status.ACTIVE.value:
                 not_defined_condition = 'NOT IS_DEFINED(c.status)'
                 condition_operand = ' OR '
 


### PR DESCRIPTION
## Description 
In many parts of the backend code, variables have been statically defined as 'active'/'inactive', this makes it difficult to maintain the code in the long term, so the use of Enums should be prioritized with this PR this objective was achieved