### PR TITLE
feat: TT-326 Get recent projects

### DIFF
--- a/cosmosdb_emulator/time_tracker_cli/factories/project_factory.py
+++ b/cosmosdb_emulator/time_tracker_cli/factories/project_factory.py
@@ -14,6 +14,7 @@ class Project(NamedTuple):
     project_type_id: int
     customer_id: str
     tenant_id: str
+    status: str
 
 
 class ProjectFactory(Factory):
@@ -28,3 +29,4 @@ class ProjectFactory(Factory):
     name = Faker('name')
     description = Faker('sentence', nb_words=10)
     tenant_id = get_time_tracker_tenant_id()
+    status = 'active'

--- a/cosmosdb_emulator/time_tracker_cli/utils/project.py
+++ b/cosmosdb_emulator/time_tracker_cli/utils/project.py
@@ -32,5 +32,6 @@ def get_project_json(project_factory: ProjectFactory) -> dict:
         'customer_id': project_factory.customer_id,
         'project_type_id': project_factory.project_type_id,
         'tenant_id': project_factory.tenant_id,
+        'status': project_factory.status,
     }
     return project

--- a/tests/time_tracker_api/projects/projects_namespace_test.py
+++ b/tests/time_tracker_api/projects/projects_namespace_test.py
@@ -309,3 +309,20 @@ def test_delete_project_should_return_unprocessable_entity_for_invalid_id_format
     repository_remove_mock.assert_called_once_with(
         str(invalid_id), {'status': Status.INACTIVE.value}, ANY
     )
+
+
+def test_get_recent_projects_should_call_method_get_recent_projects_from_project_dao(
+    client: FlaskClient, mocker: MockFixture, valid_header: dict
+):
+    project_dao_get_recent_projects_mock = mocker.patch.object(
+        ProjectCosmosDBDao, 'get_recent_projects', return_value=[]
+    )
+
+    response = client.get(
+        "/projects/recent",
+        headers=valid_header,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    project_dao_get_recent_projects_mock.assert_called_once()

--- a/tests/time_tracker_api/time_entries/time_entries_dao_test.py
+++ b/tests/time_tracker_api/time_entries/time_entries_dao_test.py
@@ -1,0 +1,49 @@
+from unittest.mock import ANY
+
+from time_tracker_api.database import APICosmosDBDao
+from time_tracker_api.time_entries.time_entries_repository import (
+    TimeEntryCosmosDBRepository,
+)
+
+
+def test_get_latest_entries_must_be_called_with_default_amount_of_entries(
+    mocker, time_entries_dao
+):
+    expected_conditions = {'owner_id': ANY}
+
+    expected_entries_amount = 20
+
+    time_entries_repository_find_all_mock = mocker.patch.object(
+        TimeEntryCosmosDBRepository, 'find_all'
+    )
+    mocker.patch.object(APICosmosDBDao, 'create_event_context')
+
+    time_entries_dao.get_latest_entries()
+
+    time_entries_repository_find_all_mock.assert_called_with(
+        conditions=expected_conditions,
+        max_count=expected_entries_amount,
+        event_context=ANY,
+    )
+
+
+def test_get_latest_entries_must_be_called_with_amount_of_entries_passed_in_condition(
+    mocker, time_entries_dao
+):
+    time_entries_repository_find_all_mock = mocker.patch.object(
+        TimeEntryCosmosDBRepository, 'find_all'
+    )
+    mocker.patch.object(APICosmosDBDao, 'create_event_context')
+
+    expected_entries_amount = 40
+    conditions = {'limit': expected_entries_amount}
+
+    time_entries_dao.get_latest_entries(conditions=conditions)
+
+    conditions.update({'owner_id': ANY})
+
+    time_entries_repository_find_all_mock.assert_called_with(
+        conditions=conditions,
+        max_count=expected_entries_amount,
+        event_context=ANY,
+    )

--- a/time_tracker_api/projects/projects_namespace.py
+++ b/time_tracker_api/projects/projects_namespace.py
@@ -193,3 +193,11 @@ class Project(Resource):
         """Delete a project"""
         project_dao.update(id, {'status': Status.INACTIVE.value})
         return None, HTTPStatus.NO_CONTENT
+
+
+@ns.route('/recent')
+class RecentProjects(Resource):
+    @ns.doc('list_recent_projects')
+    @ns.marshal_list_with(project)
+    def get(self):
+        return project_dao.get_recent_projects()


### PR DESCRIPTION
## Description
Currently there is no endpoint that allows to know which are the latest projects in which the user has created entries. This functionality is performed by an external library, which stores the projects in the local storage browser. With this PR this functionality has been created to extract the projects in which the user has generated entries, taking into account the user's last 20 entries.
