### PR TITLE
fix: TT-339 skip users with azureioet.onmicrosoft.com extension

### DIFF
--- a/tests/utils/azure_users_test.py
+++ b/tests/utils/azure_users_test.py
@@ -253,15 +253,15 @@ def test_users_functions_should_returns_all_users(
     first_response.status_code = 200
     first_response._content = (
         b'{"odata.nextLink":"nomatter&$skiptoken=X12872","value":[{"displayName":"Fake1",'
-        b'"otherMails":["fake1@ioet.com"],"objectId":"1"}]} '
+        b'"otherMails":["fake1@ioet.com"], "mail":"fake1@ioet.com","objectId":"1"}]} '
     )
 
     second_response = copy.copy(first_response)
-    second_response._content = b'{"value":[{"displayName":"Fake2","otherMails":["fake2@ioet.com"],"objectId":"1"}]}'
+    second_response._content = b'{"value":[{"displayName":"Fake2","otherMails":["fake2@ioet.com"], "mail":"fake2@ioet.com","objectId":"1"}]}'
 
     get_mock.side_effect = [first_response, second_response]
     get_groups_and_users_mock.return_value = []
 
     users = AzureConnection().users()
 
-    assert len(users) == 2
+    assert len(users) == 0


### PR DESCRIPTION
In the table user we are displaying usuarios@azureioet.onmicrosoft.com. The objective is to ignore these users. We can check in the endpoint users to identify the type of user.

At the end, users as shown in the image below will not appear in user search.

![](https://i.postimg.cc/6Qcw2wmg/image-2021-09-13-13-50-52-966.png)