### PR TITLE
fix: TT-385 adding library Flask-SQLAlchemy and pytest

### DIFF
--- a/requirements/time_tracker_api/dev.txt
+++ b/requirements/time_tracker_api/dev.txt
@@ -7,6 +7,7 @@
 
 # Tests
 pytest==5.2.0
+Flask_sqlalchemy
 
 # Mocking
 pytest-mock==2.0.0


### PR DESCRIPTION
The objective is add this packages in the dev.txt and remove from scripts "Install dependencies", I added this two packages in the sections scripts to fix the problem in azure pipelines.

```
pytest-cov
Flask-SQLAlchemy
```
<img width="1158" alt="Screen Shot 2021-10-27 at 09 27 10" src="https://user-images.githubusercontent.com/12575632/139086193-12f7c58a-e277-4d71-87f5-50628a2de587.png">

