### PR TITLE
ci: [TT-412] adds ci workflow when push to master

### DIFF
--- a/.github/workflows/time-tracker-v1-on-push-workflow.yml
+++ b/.github/workflows/time-tracker-v1-on-push-workflow.yml
@@ -2,8 +2,7 @@ name: Time Tacker V1 CI - ON PUSH
 
 on:
   push:
-    # update to master
-    branches: [TT-412-onpush]
+    branches: [master]
 
 jobs:
   time-tracker-ci-v1-on-push:
@@ -56,12 +55,13 @@ jobs:
         run: |
           pytest tests
 
-      - name: Build and push image
+      - name: Login to docker registry
         uses: azure/docker-login@v1
         with:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and push image
         run: |
           docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/timetrackerapi:${{ github.sha }}
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/timetrackerapi:${{ github.sha }}


### PR DESCRIPTION
Since our Azure DevOps pipeline has no more minutes remaining to be run, we have the need to have a new way to run the continuous integration process. That way is using GitHub Actions and this PR is to add the workflow to run some steps when code is pushed to master. It should build an image and push to ACR.

An important change is related how the image is tagged, now it will tagged with git hash.

![image](https://user-images.githubusercontent.com/59623788/143092909-c8143434-7ba1-4101-bad1-457679977f16.png)
