### PR TITLE
feat: TT-429 created enums for response messages

### DIFF
--- a/V2/time_tracker/utils/enums/__init__.py
+++ b/V2/time_tracker/utils/enums/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .response_enums import ResponseEnums

--- a/V2/time_tracker/utils/enums/response_enums.py
+++ b/V2/time_tracker/utils/enums/response_enums.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class ResponseEnums(Enum):
+    INVALID_ID = "Invalid Format ID"
+    NOT_FOUND = "Not found"
+    NOT_CREATED = "could not be created"
+    INCORRECT_BODY = "Incorrect body"
+
+    MIME_TYPE = "application/json"


### PR DESCRIPTION
enums were created so that they can be used in the reply messages, these messages were added
````
    INVALID_ID = "Invalid Format ID"
    NOT_FOUND = "Not found"
    NOT_CREATED = "could not be created"
    INCORRECT_BODY = "Incorrect body"
    MIME_TYPE = "application/json"
````