### PR TITLE
feat: TT-425 add time entries summary for a given range of dates

### DIFF
--- a/V2/serverless.yml
+++ b/V2/serverless.yml
@@ -135,6 +135,16 @@ functions:
             - GET
           route: time-entries/latest/
           authLevel: anonymous
+  
+  get_time_entries_summary:
+    handler: time_tracker/time_entries/interface.get_time_entries_summary
+    events:
+      - http: true
+        x-azure-settings:
+          methods:
+            - GET
+          route: time-entries/summary/
+          authLevel: anonymous
 
 #endregion End Functions Time-Entries
 

--- a/V2/tests/api/azure/time_entry_azure_endpoints_test.py
+++ b/V2/tests/api/azure/time_entry_azure_endpoints_test.py
@@ -297,44 +297,33 @@ def test__time_entry_azure_endpoint__returns_the_summary(
     )
 
     response = azure_time_entries.get_time_entries_summary(req)
-
     time_entries_obtained = response.get_body().decode("utf-8")
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.OK.value
     assert json.loads(time_entries_obtained) == [inserted_time_entries]
 
 
 def test__time_entry_summary_azure_endpoint__returns_not_found_with_invalid_owner_id(
     test_db, insert_activity, activity_factory
 ):
-
     insert_activity(activity_factory(), test_db)
 
     request_params = {
         "method": 'GET',
         "body": None,
         "url": TIME_ENTRY_SUMMARY_URL,
-        "params": {"owner_id": 96},
-    }
-    req_owner_id = func.HttpRequest(**request_params)
+        "params": {"owner_id": Faker().pyint()}
+        }
 
+    req_owner_id = func.HttpRequest(**request_params)
     response_owner_id = azure_time_entries._get_time_entries_summary.get_time_entries_summary(req_owner_id)
 
-    assert response_owner_id.status_code == HTTPStatus.NOT_FOUND
+    assert response_owner_id.status_code == HTTPStatus.NOT_FOUND.value
     assert response_owner_id.get_body().decode() == ResponseEnums.NOT_FOUND.value
-
-    request_params["params"] = {"owner_id": 69, "start_date": "", "end_date": "11/11/2021"}
-    req_start_date = func.HttpRequest(**request_params)
-
-    response_start_date = azure_time_entries._get_time_entries_summary.get_time_entries_summary(req_start_date)
-
-    assert response_start_date.status_code == HTTPStatus.NOT_FOUND
-    assert response_start_date.get_body().decode() == ResponseEnums.NOT_FOUND.value
 
 
 def test__time_entry_summary_azure_endpoint__returns_invalid_date_format_with_invalid_date_format(
     test_db, insert_activity, activity_factory
 ):
-
     insert_activity(activity_factory(), test_db)
 
     wrong_date_format = "30/11/2021"
@@ -350,7 +339,7 @@ def test__time_entry_summary_azure_endpoint__returns_invalid_date_format_with_in
     req_owner_id = func.HttpRequest(**request_params)
     response_owner_id = azure_time_entries._get_time_entries_summary.get_time_entries_summary(req_owner_id)
 
-    assert response_owner_id.status_code == HTTPStatus.NOT_FOUND
+    assert response_owner_id.status_code == HTTPStatus.NOT_FOUND.value
     assert response_owner_id.get_body().decode() == ResponseEnums.INVALID_DATE_FORMAT.value
 
     request_params["params"] = {"owner_id": 1, "start_date": right_date_format, "end_date": wrong_date_format}
@@ -358,5 +347,5 @@ def test__time_entry_summary_azure_endpoint__returns_invalid_date_format_with_in
 
     response_start_date = azure_time_entries._get_time_entries_summary.get_time_entries_summary(req_start_date)
 
-    assert response_start_date.status_code == HTTPStatus.NOT_FOUND
+    assert response_start_date.status_code == HTTPStatus.NOT_FOUND.value
     assert response_start_date.get_body().decode() == ResponseEnums.INVALID_DATE_FORMAT.value

--- a/V2/tests/integration/daos/time_entries_dao_test.py
+++ b/V2/tests/integration/daos/time_entries_dao_test.py
@@ -184,3 +184,32 @@ def test_get_latest_entries__returns_none__when_an_owner_id_is_not_found(
     result = dao.get_latest_entries(Faker().pyint())
 
     assert result is None
+
+
+def test_get_time_entries_summary__returns_a_list_of_time_entries__when_a_time_entry_exists_in_the_given_date_limits(
+    create_fake_dao, time_entry_factory, insert_activity, activity_factory, test_db, insert_project
+):
+    dao = create_fake_dao(test_db)
+    inserted_project = insert_project()
+    inserted_activity = insert_activity(activity_factory(), dao.db)
+    time_entry_to_insert = time_entry_factory(activity_id=inserted_activity.id,
+                                              project_id=inserted_project.id,
+                                              start_date='11/11/2021',
+                                              end_date='11/12/2021')
+    inserted_time_entry = dao.create(time_entry_to_insert).__dict__
+
+    result = dao.get_time_entries_summary(inserted_time_entry["owner_id"], '1/1/2021', '12/12/2021')
+
+    assert result == [inserted_time_entry]
+
+
+def test_get_time_entries_summary_returns_none__when_an_owner_id_or_date_limits_are_not_found(
+    create_fake_dao, test_db, insert_activity, activity_factory
+):
+    dao = create_fake_dao(test_db)
+    insert_activity(activity_factory(), dao.db)
+    result = dao.get_time_entries_summary(Faker().pyint(),
+                                          Faker().date(),
+                                          Faker().date())
+
+    assert result is None

--- a/V2/tests/unit/services/time_entry_service_test.py
+++ b/V2/tests/unit/services/time_entry_service_test.py
@@ -87,3 +87,22 @@ def test__get_latest_entries__uses_the_time_entry_dao__to_get_last_entries(
 
     assert expected_latest_time_entries == latest_time_entries
     assert time_entry_dao.get_latest_entries.called
+
+
+def test__get_time_entries_summary__uses_the_time_entry_dao__to_get_time_entries_summary(
+    mocker,
+):
+    expected_time_entries_summary = mocker.Mock()
+    time_entry_dao = mocker.Mock(
+        get_time_entries_summary=mocker.Mock(
+            return_value=expected_time_entries_summary
+        )
+    )
+
+    time_entry_service = TimeEntryService(time_entry_dao)
+    time_entries_summary = time_entry_service.get_time_entries_summary(
+        Faker().pyint(), Faker().date(), Faker().date()
+    )
+
+    assert expected_time_entries_summary == time_entries_summary
+    assert time_entry_dao.get_time_entries_summary.called

--- a/V2/tests/unit/use_cases/time_entries_use_case_test.py
+++ b/V2/tests/unit/use_cases/time_entries_use_case_test.py
@@ -88,3 +88,16 @@ def test__get_latest_entries_function__uses_the_time_entry_service__to_get_last_
 
     assert time_entry_service.get_latest_entries.called
     assert expected_latest_time_entries == latest_time_entries
+
+
+def test__get_time_entries_summary_function__uses_the_time_entry_service__to_get_summary(
+    mocker: MockFixture,
+):
+    expected_time_entries_summary = mocker.Mock()
+    time_entry_service = mocker.Mock(get_time_entries_summary=mocker.Mock(return_value=expected_time_entries_summary))
+
+    time_entry_use_case = _use_cases.GetTimeEntriesSummaryUseCase(time_entry_service)
+    summary = time_entry_use_case.get_time_entries_summary(Faker().pyint(), Faker().date(), Faker().date())
+
+    assert time_entry_service.get_time_entries_summary.called
+    assert expected_time_entries_summary == summary

--- a/V2/time_tracker/time_entries/_application/__init__.py
+++ b/V2/time_tracker/time_entries/_application/__init__.py
@@ -4,3 +4,4 @@ from ._time_entries import delete_time_entry
 from ._time_entries import update_time_entry
 from ._time_entries import get_time_entries
 from ._time_entries import get_latest_entries
+from ._time_entries import get_time_entries_summary

--- a/V2/time_tracker/time_entries/_application/_time_entries/__init__.py
+++ b/V2/time_tracker/time_entries/_application/_time_entries/__init__.py
@@ -5,3 +5,4 @@ from ._get_latest_entries import get_latest_entries
 from ._update_time_entry import update_time_entry
 from ._get_time_entries import get_time_entries
 from ._get_latest_entries import get_latest_entries
+from ._get_time_entries_summary import get_time_entries_summary

--- a/V2/time_tracker/time_entries/_application/_time_entries/_get_time_entries_summary.py
+++ b/V2/time_tracker/time_entries/_application/_time_entries/_get_time_entries_summary.py
@@ -1,0 +1,60 @@
+import json
+from http import HTTPStatus
+import datetime
+
+import azure.functions as func
+
+from ... import _domain
+from ... import _infrastructure
+from time_tracker._infrastructure import DB
+from time_tracker.utils.enums import ResponseEnums
+
+
+def get_time_entries_summary(req: func.HttpRequest) -> func.HttpResponse:
+    database = DB()
+    time_entry_dao = _infrastructure.TimeEntriesSQLDao(database)
+    time_entry_service = _domain.TimeEntryService(time_entry_dao)
+    use_case = _domain._use_cases.GetTimeEntriesSummaryUseCase(time_entry_service)
+
+    response_params = {
+        "body": ResponseEnums.NOT_FOUND.value,
+        "status_code": HTTPStatus.NOT_FOUND,
+        "mimetype": ResponseEnums.MIME_TYPE.value,
+    }
+
+    try:
+        owner_id = req.params.get("owner_id")
+        start_date = req.params.get("start_date")
+        end_date = req.params.get("end_date")
+
+        if not owner_id or not start_date or not end_date:
+            return func.HttpResponse(**response_params)
+
+        if not _validate_time_format(start_date) or not _validate_time_format(end_date):
+            response_params["body"] = ResponseEnums.INVALID_DATE_FORMAT.value
+            return func.HttpResponse(**response_params)
+
+        time_entries = use_case.get_time_entries_summary(
+            int(owner_id), start_date, end_date
+        )
+
+        if not time_entries:
+            return func.HttpResponse(**response_params)
+
+        response_params["body"] = json.dumps(time_entries, default=str)
+        response_params["status_code"] = HTTPStatus.OK
+
+        return func.HttpResponse(**response_params)
+
+    except ValueError:
+        response_params["body"] = ResponseEnums.INVALID_ID.value
+        response_params["status_code"] = HTTPStatus.BAD_REQUEST
+        return func.HttpResponse(**response_params)
+
+
+def _validate_time_format(time: str, format: str = "%m/%d/%Y"):
+    try:
+        datetime.datetime.strptime(time, format)
+    except ValueError:
+        return False
+    return True

--- a/V2/time_tracker/time_entries/_application/_time_entries/_get_time_entries_summary.py
+++ b/V2/time_tracker/time_entries/_application/_time_entries/_get_time_entries_summary.py
@@ -52,9 +52,9 @@ def get_time_entries_summary(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse(**response_params)
 
 
-def _validate_time_format(time: str, format: str = "%m/%d/%Y"):
+def _validate_time_format(time: str) -> bool:
     try:
-        datetime.datetime.strptime(time, format)
+        datetime.datetime.strptime(time, "%m/%d/%Y")
     except ValueError:
         return False
     return True

--- a/V2/time_tracker/time_entries/_domain/__init__.py
+++ b/V2/time_tracker/time_entries/_domain/__init__.py
@@ -10,4 +10,5 @@ from ._use_cases import (
     GetTimeEntriesUseCase,
     GetTimeEntryUseCase,
     GetLastestTimeEntryUseCase,
+    GetTimeEntriesSummaryUseCase,
 )

--- a/V2/time_tracker/time_entries/_domain/_persistence_contracts/_time_entries_dao.py
+++ b/V2/time_tracker/time_entries/_domain/_persistence_contracts/_time_entries_dao.py
@@ -28,3 +28,7 @@ class TimeEntriesDao(abc.ABC):
     @abc.abstractmethod
     def get_latest_entries(self, owner_id: int, limit: int) -> typing.List[TimeEntry]:
         pass
+
+    @abc.abstractmethod
+    def get_time_entries_summary(self, owner_id: int, start_date: str, end_date: str) -> typing.List[TimeEntry]:
+        pass

--- a/V2/time_tracker/time_entries/_domain/_services/_time_entry.py
+++ b/V2/time_tracker/time_entries/_domain/_services/_time_entry.py
@@ -24,3 +24,6 @@ class TimeEntryService:
 
     def get_latest_entries(self, owner_id: int, limit: int) -> typing.List[TimeEntry]:
         return self.time_entry_dao.get_latest_entries(owner_id, limit)
+
+    def get_time_entries_summary(self, owner_id: int, start_date: str, end_date: str) -> typing.List[TimeEntry]:
+        return self.time_entry_dao.get_time_entries_summary(owner_id, start_date, end_date)

--- a/V2/time_tracker/time_entries/_domain/_use_cases/__init__.py
+++ b/V2/time_tracker/time_entries/_domain/_use_cases/__init__.py
@@ -6,3 +6,4 @@ from ._update_time_entry_use_case import UpdateTimeEntryUseCase
 from ._get_time_entry_use_case import GetTimeEntriesUseCase
 from ._get_time_entry_by_id_use_case import GetTimeEntryUseCase
 from ._get_latest_entries_use_case import GetLastestTimeEntryUseCase
+from ._get_time_entries_summary_use_case import GetTimeEntriesSummaryUseCase

--- a/V2/time_tracker/time_entries/_domain/_use_cases/_get_time_entries_summary_use_case.py
+++ b/V2/time_tracker/time_entries/_domain/_use_cases/_get_time_entries_summary_use_case.py
@@ -1,0 +1,11 @@
+from time_tracker.time_entries._domain import TimeEntry, TimeEntryService
+import typing
+
+
+class GetTimeEntriesSummaryUseCase:
+
+    def __init__(self, time_entry_service: TimeEntryService):
+        self.time_entry_service = time_entry_service
+
+    def get_time_entries_summary(self, owner_id: int, start_date: str, end_date: str) -> typing.List[TimeEntry]:
+        return self.time_entry_service.get_time_entries_summary(owner_id, start_date, end_date)

--- a/V2/time_tracker/time_entries/_domain/_use_cases/_get_time_entries_summary_use_case.py
+++ b/V2/time_tracker/time_entries/_domain/_use_cases/_get_time_entries_summary_use_case.py
@@ -1,5 +1,6 @@
-from time_tracker.time_entries._domain import TimeEntry, TimeEntryService
 import typing
+
+from time_tracker.time_entries._domain import TimeEntry, TimeEntryService
 
 
 class GetTimeEntriesSummaryUseCase:

--- a/V2/time_tracker/time_entries/_infrastructure/_data_persistence/_time_entries_sql_dao.py
+++ b/V2/time_tracker/time_entries/_infrastructure/_data_persistence/_time_entries_sql_dao.py
@@ -3,6 +3,7 @@ import typing
 
 import sqlalchemy
 import sqlalchemy.sql as sql
+# from sqlalchemy import func
 
 import time_tracker.time_entries._domain as domain
 from time_tracker._infrastructure import _db
@@ -103,4 +104,20 @@ class TimeEntriesSQLDao(domain.TimeEntriesDao):
         )
         time_entries_data = self.db.get_session().execute(query)
         list_time_entries = [dict(entry) for entry in time_entries_data]
+        return list_time_entries if len(list_time_entries) > 0 else None
+
+    def get_time_entries_summary(self, owner_id: int, start_date: str, end_date: str,
+                                 format: str = "%m/%d/%Y") -> typing.List[domain.TimeEntry]:
+        query = (
+            self.time_entry.select()
+            .where(sqlalchemy.and_(self.time_entry.c.owner_id == owner_id,
+                                   self.time_entry.c.start_date.between(start_date, end_date),
+                                   self.time_entry.c.end_date.between(start_date, end_date),
+                                   self.time_entry.c.deleted.is_(False))
+                   )
+            .order_by(self.time_entry.c.start_date.desc())
+        )
+
+        time_entries = self.db.get_session().execute(query)
+        list_time_entries = [dict(entry) for entry in time_entries]
         return list_time_entries if len(list_time_entries) > 0 else None

--- a/V2/time_tracker/time_entries/_infrastructure/_data_persistence/_time_entries_sql_dao.py
+++ b/V2/time_tracker/time_entries/_infrastructure/_data_persistence/_time_entries_sql_dao.py
@@ -3,7 +3,6 @@ import typing
 
 import sqlalchemy
 import sqlalchemy.sql as sql
-# from sqlalchemy import func
 
 import time_tracker.time_entries._domain as domain
 from time_tracker._infrastructure import _db
@@ -106,8 +105,7 @@ class TimeEntriesSQLDao(domain.TimeEntriesDao):
         list_time_entries = [dict(entry) for entry in time_entries_data]
         return list_time_entries if len(list_time_entries) > 0 else None
 
-    def get_time_entries_summary(self, owner_id: int, start_date: str, end_date: str,
-                                 format: str = "%m/%d/%Y") -> typing.List[domain.TimeEntry]:
+    def get_time_entries_summary(self, owner_id: int, start_date: str, end_date: str) -> typing.List[domain.TimeEntry]:
         query = (
             self.time_entry.select()
             .where(sqlalchemy.and_(self.time_entry.c.owner_id == owner_id,

--- a/V2/time_tracker/time_entries/interface.py
+++ b/V2/time_tracker/time_entries/interface.py
@@ -5,3 +5,4 @@ from ._application import get_latest_entries
 from ._application import update_time_entry
 from ._application import get_time_entries
 from ._application import get_latest_entries
+from ._application import get_time_entries_summary

--- a/V2/time_tracker/utils/enums/response_enums.py
+++ b/V2/time_tracker/utils/enums/response_enums.py
@@ -8,3 +8,4 @@ class ResponseEnums(Enum):
     INCORRECT_BODY = "Incorrect body"
 
     MIME_TYPE = "application/json"
+    INVALID_DATE_FORMAT = "Bad time format, should use date format %m/%d/%Y"


### PR DESCRIPTION
In this branch we created a new endpoint to retrieve a time entries summary that are located between two given dates.

 **get_time_entries_summary:** [GET] http://localhost:7071/api/time-entries/summary/

Query params required: owner_id, start_date, end_date
